### PR TITLE
Add 32-bit QEMU Virt support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,9 @@ endif
 AS		=	$(CC)
 DTC		=	dtc
 
+# Guess the compillers xlen
+OPENSBI_CC_XLEN = `expr substr \`$(CC) -dumpmachine\`  6 2`
+
 # Setup compilation commands flags
 CFLAGS		=	-g -Wall -Werror -nostdlib -fno-strict-aliasing -O2
 CFLAGS		+=	-fno-omit-frame-pointer -fno-optimize-sibling-calls

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ ASFLAGS		+=	$(firmware-asflags-y)
 
 ARFLAGS		=	rcs
 
-LDFLAGS		+=	-g -Wall -nostdlib -Wl,--build-id=none -N
+LDFLAGS		+=	-g -Wall -nostdlib -Wl,--build-id=none -N -static-libgcc -lgcc
 LDFLAGS		+=	$(platform-ldflags-y)
 LDFLAGS		+=	$(firmware-ldflags-y)
 

--- a/docs/platform/qemu_virt.md
+++ b/docs/platform/qemu_virt.md
@@ -50,7 +50,7 @@ or
 ```
 qemu-system-riscv64 -M virt -m 256M -display none -serial stdio \
 	-kernel build/platform/qemu/virt/firmware/fw_jump.elf \
-	-device loader,file=<uboot_build_directory>/u-boot.bin,addr=0x80200000
+	-device loader,file=<uboot_build_directory>/u-boot.bin,addr=0x80400000
 ```
 
 **Linux Kernel Payload**
@@ -75,7 +75,7 @@ or
 ```
 qemu-system-riscv64 -M virt -m 256M -display none -serial stdio \
 	-kernel build/platform/qemu/virt/firmware/fw_jump.elf \
-	-device loader,file=<linux_build_directory>/arch/riscv/boot/Image,addr=0x80200000 \
+	-device loader,file=<linux_build_directory>/arch/riscv/boot/Image,addr=0x80400000 \
 	-drive file=<path_to_linux_rootfs>,format=raw,id=hd0 \
 	-device virtio-blk-device,drive=hd0 \
 	-append "root=/dev/vda rw console=ttyS0"

--- a/firmware/fw_base.S
+++ b/firmware/fw_base.S
@@ -69,7 +69,11 @@ _prev_arg1_override_done:
 	add	t0, a1, zero
 	and	t0, t0, a3
 	/* t2 = source FDT size in big-endian */
+#if __riscv_xlen == 64
 	lwu	t2, 4(t0)
+#else
+	lw	t2, 4(t0)
+#endif
 	/* t3 = bit[15:8] of FDT size */
 	add	t3, t2, zero
 	srli	t3, t3, 16
@@ -132,8 +136,13 @@ _start_warm:
 	 */
 	csrr	s6, mhartid
 	la	a4, platform
+#if __riscv_xlen == 64
 	lwu	s7, SBI_PLATFORM_HART_COUNT_OFFSET(a4)
 	lwu	s8, SBI_PLATFORM_HART_STACK_SIZE_OFFSET(a4)
+#else
+	lw	s7, SBI_PLATFORM_HART_COUNT_OFFSET(a4)
+	lw	s8, SBI_PLATFORM_HART_STACK_SIZE_OFFSET(a4)
+#endif
 
 	/* HART ID should be within expected limit */
 	csrr	s6, mhartid
@@ -202,8 +211,13 @@ _hartid_to_scratch:
 	 * s2 -> Temporary
 	 */
 	la	s2, platform
+#if __riscv_xlen == 64
 	lwu	s0, SBI_PLATFORM_HART_STACK_SIZE_OFFSET(s2)
 	lwu	s2, SBI_PLATFORM_HART_COUNT_OFFSET(s2)
+#else
+	lw	s0, SBI_PLATFORM_HART_STACK_SIZE_OFFSET(s2)
+	lw	s2, SBI_PLATFORM_HART_COUNT_OFFSET(s2)
+#endif
 	mul	s2, s2, s0
 	la	s1, _fw_end
 	add	s1, s1, s2

--- a/include/sbi/sbi_unpriv.h
+++ b/include/sbi/sbi_unpriv.h
@@ -77,7 +77,11 @@ static inline ulong get_insn(ulong mepc, ulong *mstatus)
 	ulong val;
 #ifndef __riscv_compressed
 	asm ("csrrs %[mstatus], mstatus, %[mprv]\n"
+#if __riscv_xlen == 64
 		STR(LWU) " %[insn], (%[addr])\n"
+#else
+		STR(LW) " %[insn], (%[addr])\n"
+#endif
 		"csrw mstatus, %[mstatus]"
 		: [mstatus] "+&r" (__mstatus), [insn] "=&r" (val)
 		: [mprv] "r" (MSTATUS_MPRV | MSTATUS_MXR), [addr] "r" (__mepc));
@@ -86,7 +90,11 @@ static inline ulong get_insn(ulong mepc, ulong *mstatus)
 	asm ("csrrs %[mstatus], mstatus, %[mprv]\n"
 		"and %[tmp], %[addr], 2\n"
 		"bnez %[tmp], 1f\n"
+#if __riscv_xlen == 64
 		STR(LWU) " %[insn], (%[addr])\n"
+#else
+		STR(LW) " %[insn], (%[addr])\n"
+#endif
 		"and %[tmp], %[insn], %[rvc_mask]\n"
 		"beq %[tmp], %[rvc_mask], 2f\n"
 		"sll %[insn], %[insn], %[xlen_minus_16]\n"

--- a/lib/sbi_ecall.c
+++ b/lib/sbi_ecall.c
@@ -39,7 +39,7 @@ int sbi_ecall_handler(u32 hartid, ulong mcause,
 	case SBI_ECALL_SET_TIMER:
 #if __riscv_xlen == 32
 		sbi_timer_event_start(scratch,
-			(((u64)regs->a1 << 32) || (u64)regs->a0));
+			(((u64)regs->a1 << 32) | (u64)regs->a0));
 #else
 		sbi_timer_event_start(scratch, (u64)regs->a0);
 #endif

--- a/lib/sbi_emulate_csr.c
+++ b/lib/sbi_emulate_csr.c
@@ -60,8 +60,7 @@ int sbi_emulate_csr_read(int csr_num,
 	case CSR_TIMEH:
 		if (!((cen >> (CSR_TIME - CSR_CYCLE)) & 1))
 			return -1;
-		*csr_val = sbi_timer_value(scratch);
-		*csr_val = *csr_val >> 32;
+		*csr_val = sbi_timer_value(scratch) >> 32;
 		break;
 	case CSR_INSTRETH:
 		if (!((cen >> (CSR_INSTRET - CSR_CYCLE)) & 1))

--- a/platform/qemu/virt/config.mk
+++ b/platform/qemu/virt/config.mk
@@ -30,10 +30,12 @@ PLATFORM_SYS_CLINT=y
 # Blobs to build
 FW_TEXT_START=0x80000000
 FW_JUMP=y
-FW_JUMP_ADDR=0x80200000
+# This needs to be 4MB alligned for 32-bit support
+FW_JUMP_ADDR=0x80400000
 FW_JUMP_FDT_ADDR=0x82200000
 FW_PAYLOAD=y
-FW_PAYLOAD_OFFSET=0x200000
+# This needs to be 4MB alligned for 32-bit support
+FW_PAYLOAD_OFFSET=0x400000
 FW_PAYLOAD_FDT_ADDR=0x82200000
 
 # External Libraries to include

--- a/platform/qemu/virt/config.mk
+++ b/platform/qemu/virt/config.mk
@@ -9,8 +9,17 @@
 
 # Compiler flags
 platform-cppflags-y =
-platform-cflags-y =-mabi=lp64 -march=rv64imafdc -mcmodel=medany
-platform-asflags-y =-mabi=lp64 -march=rv64imafdc -mcmodel=medany
+# If we know the compillers xlen use it below
+ifeq ($(OPENSBI_CC_XLEN), 32)
+	platform-cflags-y =-mabi=ilp$(OPENSBI_CC_XLEN) -march=rv$(OPENSBI_CC_XLEN)imafdc
+	platform-asflags-y =-mabi=ilp$(OPENSBI_CC_XLEN) -march=rv$(OPENSBI_CC_XLEN)imafdc
+endif
+ifeq ($(OPENSBI_CC_XLEN), 64)
+	platform-cflags-y =-mabi=lp$(OPENSBI_CC_XLEN) -march=rv$(OPENSBI_CC_XLEN)imafdc
+	platform-asflags-y =-mabi=lp$(OPENSBI_CC_XLEN) -march=rv$(OPENSBI_CC_XLEN)imafdc
+endif
+platform-cflags-y +=  -mcmodel=medany
+platform-asflags-y += -mcmodel=medany
 platform-ldflags-y =
 
 # Common drivers to enable

--- a/platform/template/config.mk
+++ b/platform/template/config.mk
@@ -12,6 +12,8 @@ platform-cppflags-y =
 # 	-mabi=lp64 -march=rv64imafdc -mcmodel=medany
 # For a 32 bits platform, this will likely be:
 # 	-mabi=lp32 -march=rv32imafdc -mcmodel=medlow
+# You can also use the Makefile variable OPENSBI_CC_XLEN for the xlen
+# See the QEMU virt machine for an example of this
 platform-cflags-y = -mabi=lp64 -march=rv64imafdc -mcmodel=medany
 platform-asflags-y = -mabi=lp64 -march=rv64imafdc -mcmodel=medany
 

--- a/platform/template/config.mk
+++ b/platform/template/config.mk
@@ -41,7 +41,8 @@ FW_TEXT_START=0x80000000
 # as needed.
 #
 FW_JUMP=<y|n>
-FW_JUMP_ADDR=0x80200000
+# This needs to be 4MB alligned for 32-bit support
+FW_JUMP_ADDR=0x80400000
 # FW_JUMP_FDT_ADDR=0x82200000
 
 #
@@ -50,7 +51,8 @@ FW_JUMP_ADDR=0x80200000
 # as needed.
 #
 FW_PAYLOAD=<y|n>
-FW_PAYLOAD_OFFSET=0x200000
+# This needs to be 4MB alligned for 32-bit support
+FW_PAYLOAD_OFFSET=0x400000
 # FW_PAYLOAD_ALIGN=0x1000
 # FW_PAYLOAD_PATH="path to next boot stage binary image file"
 # FW_PAYLOAD_FDT_PATH="path to platform flattened device tree file"


### PR DESCRIPTION
The QEMU virt machine supports both 32-bit and 64-bit RISC-V machines. This patch series adds support for the 32-bit machines.