### PR TITLE
Makefile: Add PLATFORM_RISCV_XLEN and PLATFORM_HAS_C_EXT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,27 @@ DTC		=	dtc
 # Setup compilation commands flags
 CFLAGS		=	-g -Wall -Werror -nostdlib -fno-strict-aliasing -O2
 CFLAGS		+=	-fno-omit-frame-pointer -fno-optimize-sibling-calls
-CFLAGS		+=	-mno-save-restore -mstrict-align
+CFLAGS		+=	-mno-save-restore -mstrict-align -mcmodel=medany
 CFLAGS		+=	$(GENFLAGS)
 CFLAGS		+=	$(platform-cflags-y)
 CFLAGS		+=	$(firmware-cflags-y)
+ifeq ($(PLATFORM_RISCV_XLEN), 32)
+	CFLAGS		+=	-mabi=lp32
+	ifeq ($(PLATFORM_HAS_C_EXT), y)
+		CFLAGS		+=	-march=rv32imafdc
+	else
+		CFLAGS		+=	-march=rv32imafd
+	endif
+endif
+ifeq ($(PLATFORM_RISCV_XLEN), 64)
+	CFLAGS		+=	-mabi=lp64
+	ifeq ($(PLATFORM_HAS_C_EXT), y)
+		CFLAGS		+=	-march=rv64imafdc
+	else
+		CFLAGS		+=	-march=rv64imafd
+	endif
+endif
+
 
 CPPFLAGS	+=	$(GENFLAGS)
 CPPFLAGS	+=	$(platform-cppflags-y)
@@ -130,10 +147,27 @@ CPPFLAGS	+=	$(firmware-cppflags-y)
 
 ASFLAGS		=	-g -Wall -nostdlib -D__ASSEMBLY__
 ASFLAGS		+=	-fno-omit-frame-pointer -fno-optimize-sibling-calls
-ASFLAGS		+=	-mno-save-restore -mstrict-align
+ASFLAGS		+=	-mno-save-restore -mstrict-align -mcmodel=medany
 ASFLAGS		+=	$(GENFLAGS)
 ASFLAGS		+=	$(platform-asflags-y)
 ASFLAGS		+=	$(firmware-asflags-y)
+ifeq ($(PLATFORM_RISCV_XLEN), 32)
+	ASFLAGS		+=	-mabi=lp32
+	ifeq ($(PLATFORM_HAS_C_EXT), y)
+		ASFLAGS		+=	-march=rv32imafdc
+	else
+		ASFLAGS		+=	-march=rv32imafd
+	endif
+endif
+ifeq ($(PLATFORM_RISCV_XLEN), 64)
+	ASFLAGS		+=	-mabi=lp64
+	ifeq ($(PLATFORM_HAS_C_EXT), y)
+		ASFLAGS		+=	-march=rv64imafdc
+	else
+		ASFLAGS		+=	-march=rv64imafd
+	endif
+endif
+
 
 ARFLAGS		=	rcs
 

--- a/platform/kendryte/k210/config.mk
+++ b/platform/kendryte/k210/config.mk
@@ -9,9 +9,12 @@
 
 # Compiler flags
 platform-cppflags-y =
-platform-cflags-y =-mabi=lp64 -march=rv64imafdc -mcmodel=medany
-platform-asflags-y =-mabi=lp64 -march=rv64imafdc -mcmodel=medany
+platform-cflags-y =
+platform-asflags-y =
 platform-ldflags-y =
+
+PLATFORM_RISCV_XLEN=64
+PLATFORM_HAS_C_EXT=y
 
 # Common drivers to enable
 PLATFORM_IRQCHIP_PLIC=y

--- a/platform/qemu/sifive_u/config.mk
+++ b/platform/qemu/sifive_u/config.mk
@@ -9,9 +9,12 @@
 
 # Compiler flags
 platform-cppflags-y =
-platform-cflags-y =-mabi=lp64 -march=rv64imafdc -mcmodel=medany
-platform-asflags-y =-mabi=lp64 -march=rv64imafdc -mcmodel=medany
+platform-cflags-y =
+platform-asflags-y =
 platform-ldflags-y =
+
+PLATFORM_RISCV_XLEN=64
+PLATFORM_HAS_C_EXT=y
 
 # Common drivers to enable
 PLATFORM_IRQCHIP_PLIC=y

--- a/platform/qemu/virt/config.mk
+++ b/platform/qemu/virt/config.mk
@@ -9,9 +9,12 @@
 
 # Compiler flags
 platform-cppflags-y =
-platform-cflags-y =-mabi=lp64 -march=rv64imafdc -mcmodel=medany
-platform-asflags-y =-mabi=lp64 -march=rv64imafdc -mcmodel=medany
+platform-cflags-y =
+platform-asflags-y =
 platform-ldflags-y =
+
+PLATFORM_RISCV_XLEN=64
+PLATFORM_HAS_C_EXT=y
 
 # Common drivers to enable
 PLATFORM_IRQCHIP_PLIC=y

--- a/platform/sifive/fu540/config.mk
+++ b/platform/sifive/fu540/config.mk
@@ -9,9 +9,12 @@
 
 # Compiler flags
 platform-cppflags-y =
-platform-cflags-y =-mabi=lp64 -march=rv64imafdc -mcmodel=medany
-platform-asflags-y =-mabi=lp64 -march=rv64imafdc -mcmodel=medany
+platform-cflags-y =
+platform-asflags-y =
 platform-ldflags-y =
+
+PLATFORM_RISCV_XLEN=64
+PLATFORM_HAS_C_EXT=y
 
 # Common drivers to enable
 PLATFORM_IRQCHIP_PLIC=y

--- a/platform/template/config.mk
+++ b/platform/template/config.mk
@@ -8,12 +8,12 @@
 platform-cppflags-y =
 
 # C Compiler and assembler flags.
-# For a 64 bits platform, this will likely be:
-# 	-mabi=lp64 -march=rv64imafdc -mcmodel=medany
-# For a 32 bits platform, this will likely be:
-# 	-mabi=lp32 -march=rv32imafdc -mcmodel=medlow
-platform-cflags-y = -mabi=lp64 -march=rv64imafdc -mcmodel=medany
-platform-asflags-y = -mabi=lp64 -march=rv64imafdc -mcmodel=medany
+platform-cflags-y =
+platform-asflags-y =
+
+# If you always know these you can set them here, otherwise we will use the compiler defaults
+PLATFORM_RISCV_XLEN=64
+PLATFORM_HAS_C_EXT=y
 
 # Linker flags: additional libraries and object files that the platform
 # code needs can be added here


### PR DESCRIPTION
Make the build system more generic by adding variables to specify the
build flags.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>