### PR TITLE
docs: Use normal hyphen instead of non-breaking hyphen

### DIFF
--- a/docs/platform/sifive_fu540.md
+++ b/docs/platform/sifive_fu540.md
@@ -1,6 +1,6 @@
 SiFive FU540 SoC Platform
 ==========================
-The FU540-C000 is the world’s first 4+1 64-bit RISC‑V SoC from SiFive.
+The FU540-C000 is the world’s first 4+1 64-bit RISC-V SoC from SiFive.
 The HiFive Unleashed development platform is based on FU540-C000 and capable
 of running Linux.
 


### PR DESCRIPTION
Usage non-breaking hyphen breaks make docs as doxygen doesn't know
how to handle this.

This fixes make doc failure issue.

Signed-off-by: Atish Patra <atish.patra@wdc.com>