### PR TITLE
csr fix

### DIFF
--- a/firmware/fw_base.S
+++ b/firmware/fw_base.S
@@ -22,7 +22,7 @@ _start:
 	 * Jump to warm-boot if this is not the first core booting,
 	 * that is, for mhartid != 0
 	 */
-	csrr	a6, mhartid
+	csrr	a6, CSR_MHARTID
 	blt	zero, a6, _wait_for_boot_hart
 
 	/* Zero-out BSS */
@@ -126,15 +126,15 @@ _wait_for_boot_hart:
 
 _start_warm:
 	/* Disable and clear all interrupts */
-	csrw	mie, zero
-	csrw	mip, zero
+	csrw	CSR_MIE, zero
+	csrw	CSR_MIP, zero
 
 	/* Preload per-HART details
 	 * s6 -> HART ID
 	 * s7 -> HART Count
 	 * s8 -> HART Stack Size
 	 */
-	csrr	s6, mhartid
+	csrr	s6, CSR_MHARTID
 	la	a4, platform
 #if __riscv_xlen == 64
 	lwu	s7, SBI_PLATFORM_HART_COUNT_OFFSET(a4)
@@ -145,7 +145,7 @@ _start_warm:
 #endif
 
 	/* HART ID should be within expected limit */
-	csrr	s6, mhartid
+	csrr	s6, CSR_MHARTID
 	bge	s6, s7, _start_hang
 
 	/* Setup scratch space */
@@ -156,7 +156,7 @@ _start_warm:
 	sub	tp, tp, a5
 	li	a5, SBI_SCRATCH_SIZE
 	sub	tp, tp, a5
-	csrw	mscratch, tp
+	csrw	CSR_MSCRATCH, tp
 
 	/* Initialize scratch space */
 	la	a4, _fw_start
@@ -187,11 +187,11 @@ _start_warm:
 
 	/* Setup trap handler */
 	la	a4, _trap_handler
-	csrw	mtvec, a4
+	csrw	CSR_MTVEC, a4
 
 	/* Initialize SBI runtime */
-	csrr	a0, mscratch
-	call	sbi_init
+	csrr	a0, CSR_MSCRATCH
+	Call	sbi_init
 
 	/* We don't expect to reach here hence just hang */
 	j	_start_hang
@@ -243,7 +243,7 @@ _start_hang:
 	.globl _trap_handler
 _trap_handler:
 	/* Swap SP and MSCRATCH */
-	csrrw	sp, mscratch, sp
+	csrrw	sp, CSR_MSCRATCH, sp
 
 	/* Setup exception stack */
 	add	sp, sp, -(SBI_TRAP_REGS_SIZE)
@@ -256,12 +256,12 @@ _trap_handler:
 
 	/* Save original SP and restore MSCRATCH */
 	add	t0, sp, SBI_TRAP_REGS_SIZE
-	csrrw	t0, mscratch, t0
+	csrrw	t0, CSR_MSCRATCH, t0
 	REG_S	t0, SBI_TRAP_REGS_OFFSET(sp)(sp)
 
 	/* Save MEPC and MSTATUS CSRs */
-	csrr	t0, mepc
-	csrr	t1, mstatus
+	csrr	t0, CSR_MEPC
+	csrr	t1, CSR_MSTATUS
 
 	/*
 	 * Note: Fast path trap handling can be done here
@@ -305,7 +305,7 @@ _trap_handler:
 
 	/* Call C routine */
 	add	a0, sp, zero
-	csrr	a1, mscratch
+	csrr	a1, CSR_MSCRATCH
 	call	sbi_trap_handler
 
 	/* Restore all general regisers except SP, RA, T0, T1, T2, and T3 */
@@ -348,8 +348,8 @@ _trap_handler:
 	 */
 
 	/* Restore MEPC and MSTATUS CSRs */
-	csrw	mepc, t0
-	csrw	mstatus, t1
+	csrw	CSR_MEPC, t0
+	csrw	CSR_MSTATUS, t1
 
 	/* Restore RA, T0, T1, and T2 */
 	REG_L	ra, SBI_TRAP_REGS_OFFSET(ra)(sp)

--- a/firmware/payloads/test_head.S
+++ b/firmware/payloads/test_head.S
@@ -7,6 +7,7 @@
  *   Anup Patel <anup.patel@wdc.com>
  */
 
+#include <sbi/riscv_encoding.h>
 #define __ASM_STR(x)	x
 
 #if __riscv_xlen == 64
@@ -48,12 +49,12 @@ _bss_zero:
 
 _start_warm:
 	/* Disable and clear all interrupts */
-	csrw	sie, zero
-	csrw	sip, zero
+	csrw	CSR_SIE, zero
+	csrw	CSR_SIP, zero
 
 	/* Setup exception vectors */
 	la	a3, _start_hang
-	csrw	stvec, a3
+	csrw	CSR_STVEC, a3
 
 	/* Setup stack */
 	la	a3, _payload_end

--- a/include/sbi/riscv_encoding.h
+++ b/include/sbi/riscv_encoding.h
@@ -195,10 +195,18 @@
 #define RISCV_PGSHIFT			12
 #define RISCV_PGSIZE			(1 << RISCV_PGSHIFT)
 
+#define CSR_USTATUS			0x0
 #define CSR_FFLAGS			0x1
 #define CSR_FRM				0x2
 #define CSR_FCSR			0x3
 #define CSR_CYCLE			0xc00
+#define CSR_UIE				0x4
+#define CSR_UTVEC			0x5
+#define CSR_USCRATCH			0x40
+#define CSR_UEPC			0x41
+#define CSR_UCAUSE			0x42
+#define CSR_UTVAL			0x43
+#define CSR_UIP				0x44
 #define CSR_TIME			0xc01
 #define CSR_INSTRET			0xc02
 #define CSR_HPMCOUNTER3			0xc03

--- a/include/sbi/riscv_fp.h
+++ b/include/sbi/riscv_fp.h
@@ -43,12 +43,12 @@
   ulong offset = SHIFT_RIGHT(insn, (pos)-3) & 0xf8; \
   ulong tmp; \
   asm volatile ("1: auipc %0, %%pcrel_hi(put_f64_reg); add %0, %0, %2; jalr t0, %0, %%pcrel_lo(1b)" : "=&r"(tmp) : "r"(value), "r"(offset) : "t0"); })
-#define GET_FCSR() csr_read(fcsr)
-#define SET_FCSR(value) csr_write(fcsr, (value))
-#define GET_FRM() csr_read(frm)
-#define SET_FRM(value) csr_write(frm, (value))
-#define GET_FFLAGS() csr_read(fflags)
-#define SET_FFLAGS(value) csr_write(fflags, (value))
+#define GET_FCSR() csr_read(CSR_FCSR)
+#define SET_FCSR(value) csr_write(CSR_FCSR, (value))
+#define GET_FRM() csr_read(CSR_FRM)
+#define SET_FRM(value) csr_write(CSR_FRM, (value))
+#define GET_FFLAGS() csr_read(CSR_FFLAGS)
+#define SET_FFLAGS(value) csr_write(CSR_FFLAGS, (value))
 
 #define SET_FS_DIRTY() ((void) 0)
 

--- a/include/sbi/sbi_scratch.h
+++ b/include/sbi/sbi_scratch.h
@@ -61,7 +61,7 @@ struct sbi_scratch {
 
 /** Get pointer to sbi_scratch for current HART */
 #define sbi_scratch_thishart_ptr()	\
-((struct sbi_scratch *)csr_read(mscratch))
+((struct sbi_scratch *)csr_read(CSR_MSCRATCH))
 
 /** Get Arg1 of next booting stage for current HART */
 #define sbi_scratch_thishart_arg1_ptr()	\

--- a/include/sbi/sbi_unpriv.h
+++ b/include/sbi/sbi_unpriv.h
@@ -20,9 +20,9 @@ static inline type load_##type(const type *addr, ulong mepc)		\
 	register ulong __mepc asm ("a2") = mepc;			\
 	register ulong __mstatus asm ("a3");				\
 	type val;							\
-	asm ("csrrs %0, mstatus, %3\n"					\
+	asm ("csrrs %0, "STR(CSR_MSTATUS)", %3\n"					\
 		#insn " %1, %2\n"					\
-		"csrw mstatus, %0"					\
+		"csrw "STR(CSR_MSTATUS)", %0"					\
 	: "+&r" (__mstatus), "=&r" (val)				\
 	: "m" (*addr), "r" (MSTATUS_MPRV), "r" (__mepc));		\
 	return val;							\
@@ -33,9 +33,9 @@ static inline void store_##type(type *addr, type val, ulong mepc)	\
 {									\
 	register ulong __mepc asm ("a2") = mepc;			\
 	register ulong __mstatus asm ("a3");				\
-	asm volatile ("csrrs %0, mstatus, %3\n"				\
+	asm volatile ("csrrs %0, "STR(CSR_MSTATUS)", %3\n"				\
 		#insn " %1, %2\n"					\
-		"csrw mstatus, %0"					\
+		"csrw "STR(CSR_MSTATUS)", %0"					\
 	: "+&r" (__mstatus)						\
 	: "r" (val), "m" (*addr), "r" (MSTATUS_MPRV), "r" (__mepc));	\
 }
@@ -76,18 +76,18 @@ static inline ulong get_insn(ulong mepc, ulong *mstatus)
 	register ulong __mstatus asm ("a3");
 	ulong val;
 #ifndef __riscv_compressed
-	asm ("csrrs %[mstatus], mstatus, %[mprv]\n"
+	asm ("csrrs %[mstatus], "STR(CSR_MSTATUS)", %[mprv]\n"
 #if __riscv_xlen == 64
 		STR(LWU) " %[insn], (%[addr])\n"
 #else
 		STR(LW) " %[insn], (%[addr])\n"
 #endif
-		"csrw mstatus, %[mstatus]"
+		"csrw "STR(CSR_MSTATUS)", %[mstatus]"
 		: [mstatus] "+&r" (__mstatus), [insn] "=&r" (val)
 		: [mprv] "r" (MSTATUS_MPRV | MSTATUS_MXR), [addr] "r" (__mepc));
 #else
 	ulong rvc_mask = 3, tmp;
-	asm ("csrrs %[mstatus], mstatus, %[mprv]\n"
+	asm ("csrrs %[mstatus], "STR(CSR_MSTATUS)", %[mprv]\n"
 		"and %[tmp], %[addr], 2\n"
 		"bnez %[tmp], 1f\n"
 #if __riscv_xlen == 64
@@ -107,7 +107,7 @@ static inline ulong get_insn(ulong mepc, ulong *mstatus)
 		"lhu %[tmp], 2(%[addr])\n"
 		"sll %[tmp], %[tmp], 16\n"
 		"add %[insn], %[insn], %[tmp]\n"
-		"2: csrw mstatus, %[mstatus]"
+		"2: csrw "STR(CSR_MSTATUS)", %[mstatus]"
 	: [mstatus] "+&r" (__mstatus), [insn] "=&r" (val), [tmp] "=&r" (tmp)
 	: [mprv] "r" (MSTATUS_MPRV | MSTATUS_MXR), [addr] "r" (__mepc),
 	[rvc_mask] "r" (rvc_mask), [xlen_minus_16] "i" (__riscv_xlen - 16));

--- a/lib/sbi_emulate_csr.c
+++ b/lib/sbi_emulate_csr.c
@@ -23,13 +23,13 @@ int sbi_emulate_csr_read(int csr_num,
 	ulong cen = -1UL;
 
 	if (EXTRACT_FIELD(mstatus, MSTATUS_MPP) == PRV_U)
-		cen = csr_read(scounteren);
+		cen = csr_read(CSR_SCOUNTEREN);
 
 	switch (csr_num) {
 	case CSR_CYCLE:
 		if (!((cen >> (CSR_CYCLE - CSR_CYCLE)) & 1))
 			return -1;
-		*csr_val = csr_read(mcycle);
+		*csr_val = csr_read(CSR_MCYCLE);
 		break;
 	case CSR_TIME:
 		if (!((cen >> (CSR_TIME - CSR_CYCLE)) & 1))
@@ -39,23 +39,23 @@ int sbi_emulate_csr_read(int csr_num,
 	case CSR_INSTRET:
 		if (!((cen >> (CSR_INSTRET - CSR_CYCLE)) & 1))
 			return -1;
-		*csr_val = csr_read(minstret);
+		*csr_val = csr_read(CSR_MINSTRET);
 		break;
 	case CSR_MHPMCOUNTER3:
 		if (!((cen >> (3 + CSR_MHPMCOUNTER3 - CSR_MHPMCOUNTER3)) & 1))
 			return -1;
-		*csr_val = csr_read(mhpmcounter3);
+		*csr_val = csr_read(CSR_MHPMCOUNTER3);
 		break;
 	case CSR_MHPMCOUNTER4:
 		if (!((cen >> (3 + CSR_MHPMCOUNTER4 - CSR_MHPMCOUNTER3)) & 1))
 			return -1;
-		*csr_val = csr_read(mhpmcounter4);
+		*csr_val = csr_read(CSR_MHPMCOUNTER4);
 		break;
 #if __riscv_xlen == 32
 	case CSR_CYCLEH:
 		if (!((cen >> (CSR_CYCLE - CSR_CYCLE)) & 1))
 			return -1;
-		*csr_val = csr_read(mcycleh);
+		*csr_val = csr_read(CSR_MCYCLEH);
 		break;
 	case CSR_TIMEH:
 		if (!((cen >> (CSR_TIME - CSR_CYCLE)) & 1))
@@ -65,24 +65,24 @@ int sbi_emulate_csr_read(int csr_num,
 	case CSR_INSTRETH:
 		if (!((cen >> (CSR_INSTRET - CSR_CYCLE)) & 1))
 			return -1;
-		*csr_val = csr_read(minstreth);
+		*csr_val = csr_read(CSR_MINSTRETH);
 		break;
 	case CSR_MHPMCOUNTER3H:
 		if (!((cen >> (3 + CSR_MHPMCOUNTER3 - CSR_MHPMCOUNTER3)) & 1))
 			return -1;
-		*csr_val = csr_read(mhpmcounter3h);
+		*csr_val = csr_read(CSR_MHPMCOUNTER3H);
 		break;
 	case CSR_MHPMCOUNTER4H:
 		if (!((cen >> (3 + CSR_MHPMCOUNTER4 - CSR_MHPMCOUNTER3)) & 1))
 			return -1;
-		*csr_val = csr_read(mhpmcounter4h);
+		*csr_val = csr_read(CSR_MHPMCOUNTER4H);
 		break;
 #endif
 	case CSR_MHPMEVENT3:
-		*csr_val = csr_read(mhpmevent3);
+		*csr_val = csr_read(CSR_MHPMEVENT3);
 		break;
 	case CSR_MHPMEVENT4:
-		*csr_val = csr_read(mhpmevent4);
+		*csr_val = csr_read(CSR_MHPMEVENT4);
 		break;
 	default:
 		sbi_printf("%s: hartid%d: invalid csr_num=0x%x\n",
@@ -100,36 +100,36 @@ int sbi_emulate_csr_write(int csr_num,
 {
 	switch (csr_num) {
 	case CSR_CYCLE:
-		csr_write(mcycle, csr_val);
+		csr_write(CSR_MCYCLE, csr_val);
 		break;
 	case CSR_INSTRET:
-		csr_write(minstret, csr_val);
+		csr_write(CSR_MINSTRET, csr_val);
 		break;
 	case CSR_MHPMCOUNTER3:
-		csr_write(mhpmcounter3, csr_val);
+		csr_write(CSR_MHPMCOUNTER3, csr_val);
 		break;
 	case CSR_MHPMCOUNTER4:
-		csr_write(mhpmcounter4, csr_val);
+		csr_write(CSR_MHPMCOUNTER4, csr_val);
 		break;
 #if __riscv_xlen == 32
 	case CSR_CYCLEH:
-		csr_write(mcycleh, csr_val);
+		csr_write(CSR_MCYCLEH, csr_val);
 		break;
 	case CSR_INSTRETH:
-		csr_write(minstreth, csr_val);
+		csr_write(CSR_MINSTRETH, csr_val);
 		break;
 	case CSR_MHPMCOUNTER3H:
-		csr_write(mhpmcounter3h, csr_val);
+		csr_write(CSR_MHPMCOUNTER3H, csr_val);
 		break;
 	case CSR_MHPMCOUNTER4H:
-		csr_write(mhpmcounter4h, csr_val);
+		csr_write(CSR_MHPMCOUNTER4H, csr_val);
 		break;
 #endif
 	case CSR_MHPMEVENT3:
-		csr_write(mhpmevent3, csr_val);
+		csr_write(CSR_MHPMEVENT3, csr_val);
 		break;
 	case CSR_MHPMEVENT4:
-		csr_write(mhpmevent4, csr_val);
+		csr_write(CSR_MHPMEVENT4, csr_val);
 		break;
 	default:
 		sbi_printf("%s: hartid%d: invalid csr_num=0x%x\n",

--- a/lib/sbi_illegal_insn.c
+++ b/lib/sbi_illegal_insn.c
@@ -127,7 +127,7 @@ int sbi_illegal_insn_handler(u32 hartid, ulong mcause,
 
 	if (unlikely((insn & 3) != 3)) {
 		if (insn == 0) {
-			mstatus = csr_read(mstatus);
+			mstatus = csr_read(CSR_MSTATUS);
 			insn = get_insn(regs->mepc, &mstatus);
 		}
 		if ((insn & 3) != 3)

--- a/lib/sbi_ipi.c
+++ b/lib/sbi_ipi.c
@@ -27,7 +27,7 @@ int sbi_ipi_send_many(struct sbi_scratch *scratch,
 	struct sbi_platform *plat = sbi_platform_ptr(scratch);
 
 	if (pmask)
-		mask &= load_ulong(pmask, csr_read(mepc));
+		mask &= load_ulong(pmask, csr_read(CSR_MEPC));
 
 	/* send IPIs to everyone */
 	for (i = 0, m = mask; m; i++, m >>= 1) {
@@ -46,7 +46,7 @@ int sbi_ipi_send_many(struct sbi_scratch *scratch,
 
 void sbi_ipi_clear_smode(struct sbi_scratch *scratch)
 {
-	csr_clear(mip, MIP_SSIP);
+	csr_clear(CSR_MIP, MIP_SSIP);
 }
 
 void sbi_ipi_process(struct sbi_scratch *scratch)
@@ -64,7 +64,7 @@ void sbi_ipi_process(struct sbi_scratch *scratch)
 		ipi_event = __ffs(ipi_type);
 		switch (ipi_event) {
 		case SBI_IPI_EVENT_SOFT:
-			csr_set(mip, MIP_SSIP);
+			csr_set(CSR_MIP, MIP_SSIP);
 			break;
 		case SBI_IPI_EVENT_FENCE_I:
 			__asm__ __volatile("fence.i");
@@ -83,7 +83,7 @@ void sbi_ipi_process(struct sbi_scratch *scratch)
 int sbi_ipi_init(struct sbi_scratch *scratch, bool cold_boot)
 {
 	/* Enable software interrupts */
-	csr_set(mie, MIP_MSIP);
+	csr_set(CSR_MIE, MIP_MSIP);
 
 	return sbi_platform_ipi_init(sbi_platform_ptr(scratch),
 				     cold_boot);

--- a/lib/sbi_misaligned_ldst.c
+++ b/lib/sbi_misaligned_ldst.c
@@ -26,7 +26,7 @@ int sbi_misaligned_load_handler(u32 hartid, ulong mcause,
 				struct sbi_scratch *scratch)
 {
 	union reg_data val;
-	ulong mstatus = csr_read(mstatus);
+	ulong mstatus = csr_read(CSR_MSTATUS);
 	ulong insn = get_insn(regs->mepc, &mstatus);
 	ulong addr = csr_read(CSR_MTVAL);
 	int i, fp = 0, shift = 0, len = 0;
@@ -112,7 +112,7 @@ int sbi_misaligned_store_handler(u32 hartid, ulong mcause,
 				 struct sbi_scratch *scratch)
 {
 	union reg_data val;
-	ulong mstatus = csr_read(mstatus);
+	ulong mstatus = csr_read(CSR_MSTATUS);
 	ulong insn = get_insn(regs->mepc, &mstatus);
 	ulong addr = csr_read(CSR_MTVAL);
 	int i, len = 0;

--- a/lib/sbi_timer.c
+++ b/lib/sbi_timer.c
@@ -56,14 +56,14 @@ void sbi_timer_event_start(struct sbi_scratch *scratch, u64 next_event)
 {
 	sbi_platform_timer_event_start(sbi_platform_ptr(scratch),
 				       next_event);
-	csr_clear(mip, MIP_STIP);
-	csr_set(mie, MIP_MTIP);
+	csr_clear(CSR_MIP, MIP_STIP);
+	csr_set(CSR_MIE, MIP_MTIP);
 }
 
 void sbi_timer_process(struct sbi_scratch *scratch)
 {
-	csr_clear(mie, MIP_MTIP);
-	csr_set(mip, MIP_STIP);
+	csr_clear(CSR_MIE, MIP_MTIP);
+	csr_set(CSR_MIP, MIP_STIP);
 }
 
 int sbi_timer_init(struct sbi_scratch *scratch, bool cold_boot)

--- a/lib/sbi_trap.c
+++ b/lib/sbi_trap.c
@@ -94,7 +94,7 @@ int sbi_trap_redirect(struct sbi_trap_regs *regs,
 	csr_write(CSR_SCAUSE, cause);
 
 	/* Set MEPC to S-mode exception vector base */
-	regs->mepc = csr_read(stvec);
+	regs->mepc = csr_read(CSR_STVEC);
 
 	/* Initial value of new MSTATUS */
 	new_mstatus = regs->mstatus;
@@ -141,7 +141,7 @@ void sbi_trap_handler(struct sbi_trap_regs *regs,
 	int rc = SBI_ENOTSUPP;
 	const char *msg = "trap handler failed";
 	u32 hartid = sbi_current_hartid();
-	ulong mcause = csr_read(mcause);
+	ulong mcause = csr_read(CSR_MCAUSE);
 
 	if (mcause & (1UL << (__riscv_xlen - 1))) {
 		mcause &= ~(1UL << (__riscv_xlen - 1));

--- a/platform/kendryte/k210/platform.h
+++ b/platform/kendryte/k210/platform.h
@@ -88,7 +88,7 @@
 #define SPI1_BASE_ADDR		(0x53000000U)
 #define SPI3_BASE_ADDR		(0x54000000U)
 
-#define read_cycle()		csr_read(mcycle)
+#define read_cycle()		csr_read(CSR_MCYCLE)
 
 /*
  * PLIC External Interrupt Numbers


### PR DESCRIPTION
Some older toolchain may not have all csr defined.
Update all csr functions to use defined CSR_ values instead of
toolchain defined values.

This fixes #49 