### PR TITLE
Makefile: Fix compilation on RV32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,8 @@ LDFLAGS		+=	$(platform-ldflags-y)
 LDFLAGS		+=	$(firmware-ldflags-y)
 
 MERGEFLAGS	+=	-r
+MERGEFLAGS	+=	-b elf$(PLATFORM_RISCV_XLEN)-littleriscv
+MERGEFLAGS	+=	-m elf$(PLATFORM_RISCV_XLEN)lriscv
 
 DTCFLAGS	=	-O dtb
 
@@ -225,7 +227,7 @@ compile_as = $(CMD_PREFIX)mkdir -p `dirname $(1)`; \
 	     $(AS) $(ASFLAGS) $(call dynamic_flags,$(1),$(2)) -c $(2) -o $(1)
 compile_ld = $(CMD_PREFIX)mkdir -p `dirname $(1)`; \
 	     echo " LD        $(subst $(build_dir)/,,$(1))"; \
-	     $(CC) $(3) $(LDFLAGS) -Wl,-T$(2) -o $(1)
+	     $(CC) $(CFLAGS) $(3) $(LDFLAGS) -Wl,-T$(2) -o $(1)
 compile_ar = $(CMD_PREFIX)mkdir -p `dirname $(1)`; \
 	     echo " AR        $(subst $(build_dir)/,,$(1))"; \
 	     $(AR) $(ARFLAGS) $(1) $(2)


### PR DESCRIPTION
On Makefile merge_objs calls ld without providing any hints on the target so on a multilib toolchain for example it will always pick the default one (elf64-littleriscv) which will then result a failure when compiling on RV32 since the objects will be 32bits and the target will be 64bits. The same happens on compile_ld that calls gcc without CFLAGS so it doesn't get mabi/march.

With this patch OpenSBI compiles on RV32 (PLATFORM_RISCV_XLEN=32), I tested fw_jump.elf on qemu (but it doesn't boot the kernel yet -bbl also doesn't boot the kernel so it may be something else).

Note that currently the newlib toolchain from riscv-gnu-toolchain doesn't support rv32imafdc (only rv32imafc) so since OpenSBI requires the d extension, it will not find the proper libgcc.a and default to the 64bit one, again resulting a failure. The glibc toolchain on the other hand works fine (and it doesn't really matter since we don't link with libc due to -nostdlib).