### PR TITLE
Add 'make run' command for platform specific run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,6 +316,21 @@ all-deps-2 = $(if $(findstring clean,$(MAKECMDGOALS)),,$(all-deps-1))
 # Include external dependency of firmwares after default Makefile rules
 include $(src_dir)/firmware/external_deps.mk
 
+# Convenient "make run" command for emulated platforms
+.PHONY: run
+run: all
+ifneq ($(platform-runcmd),)
+	$(platform-runcmd) $(RUN_ARGS)
+else
+ifdef PLATFORM
+	@echo Platform $(PLATFORM) doesn't specify a run command
+	@false
+else
+	@echo Run command only available when targeting a platform
+	@false
+endif
+endif
+
 install_targets-y  = install_libsbi
 ifdef PLATFORM
 install_targets-y += install_libplatsbi

--- a/platform/qemu/sifive_u/config.mk
+++ b/platform/qemu/sifive_u/config.mk
@@ -13,6 +13,10 @@ platform-cflags-y =
 platform-asflags-y =
 platform-ldflags-y =
 
+# Command for platform specific "make run"
+platform-runcmd = qemu-system-riscv$(PLATFORM_RISCV_XLEN) -M sifive_u -m 256M \
+  -nographic -kernel $(build_dir)/platform/qemu/sifive_u/firmware/fw_payload.elf
+
 # Common drivers to enable
 PLATFORM_IRQCHIP_PLIC=y
 PLATFORM_SERIAL_SIFIVE_UART=y
@@ -21,7 +25,7 @@ PLATFORM_SYS_CLINT=y
 # Blobs to build
 FW_TEXT_START=0x80000000
 FW_JUMP=y
-ifeq ($(OPENSBI_CC_XLEN), 32)
+ifeq ($(PLATFORM_RISCV_XLEN), 32)
   # This needs to be 4MB alligned for 32-bit system
   FW_JUMP_ADDR=0x80400000
 else
@@ -30,7 +34,7 @@ else
 endif
 FW_JUMP_FDT_ADDR=0x82200000
 FW_PAYLOAD=y
-ifeq ($(OPENSBI_CC_XLEN), 32)
+ifeq ($(PLATFORM_RISCV_XLEN), 32)
   # This needs to be 4MB alligned for 32-bit system
   FW_PAYLOAD_OFFSET=0x400000
 else

--- a/platform/qemu/virt/config.mk
+++ b/platform/qemu/virt/config.mk
@@ -13,6 +13,10 @@ platform-cflags-y =
 platform-asflags-y =
 platform-ldflags-y =
 
+# Command for platform specific "make run"
+platform-runcmd = qemu-system-riscv$(PLATFORM_RISCV_XLEN) -M virt -m 256M \
+  -nographic -kernel $(build_dir)/platform/qemu/virt/firmware/fw_payload.elf
+
 # Common drivers to enable
 PLATFORM_IRQCHIP_PLIC=y
 PLATFORM_SERIAL_UART8250=y
@@ -21,7 +25,7 @@ PLATFORM_SYS_CLINT=y
 # Blobs to build
 FW_TEXT_START=0x80000000
 FW_JUMP=y
-ifeq ($(OPENSBI_CC_XLEN), 32)
+ifeq ($(PLATFORM_RISCV_XLEN), 32)
   # This needs to be 4MB alligned for 32-bit system
   FW_JUMP_ADDR=0x80400000
 else
@@ -30,7 +34,7 @@ else
 endif
 FW_JUMP_FDT_ADDR=0x82200000
 FW_PAYLOAD=y
-ifeq ($(OPENSBI_CC_XLEN), 32)
+ifeq ($(PLATFORM_RISCV_XLEN), 32)
   # This needs to be 4MB alligned for 32-bit system
   FW_PAYLOAD_OFFSET=0x400000
 else

--- a/platform/template/config.mk
+++ b/platform/template/config.mk
@@ -16,6 +16,12 @@ platform-asflags-y =
 platform-ldflags-y =
 
 #
+# Command for platform specific "make run"
+# Useful for development and debugging on plaftform simulator (such as QEMU)
+#
+# platform-runcmd = your_platform_run.sh
+
+#
 # Platform RISC-V XLEN, ABI, ISA and Code Model configuration.
 # These are optional parameters but platforms can optionaly provide it.
 # Some of these are guessed based on GCC compiler capabilities
@@ -47,7 +53,7 @@ FW_TEXT_START=0x80000000
 FW_JUMP=<y|n>
 # This needs to be 4MB aligned for 32-bit support
 # This needs to be 2MB aligned for 64-bit support
-# ifeq ($(OPENSBI_CC_XLEN), 32)
+# ifeq ($(PLATFORM_RISCV_XLEN), 32)
 # FW_JUMP_ADDR=0x80400000
 # else
 # FW_JUMP_ADDR=0x80200000
@@ -62,7 +68,7 @@ FW_JUMP=<y|n>
 FW_PAYLOAD=<y|n>
 # This needs to be 4MB aligned for 32-bit support
 # This needs to be 2MB aligned for 64-bit support
-ifeq ($(OPENSBI_CC_XLEN), 32)
+ifeq ($(PLATFORM_RISCV_XLEN), 32)
 FW_PAYLOAD_OFFSET=0x400000
 else
 FW_PAYLOAD_OFFSET=0x200000


### PR DESCRIPTION
Makes for easy and quick build-run one-stop command.

For now only added for qemu targets. It can be added for
any platform having simulator/emulator (such as QEMU).

Signed-off-by: Olof Johansson <olof@lixom.net>
Signed-off-by: Anup Patel <anup.patel@wdc.com>