### PR TITLE
Makefile: Set the platform variables before parsing the platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,15 @@ DTC		=	dtc
 # Guess the compillers xlen
 OPENSBI_CC_XLEN := $(shell TMP=`$(CC) -dumpmachine | sed 's/riscv\([0-9][0-9]\).*/\1/'`; echo $${TMP})
 
+# Setup platform XLEN, ABI, ISA and Code Model
+ifndef PLATFORM_RISCV_XLEN
+  ifeq ($(OPENSBI_CC_XLEN), 32)
+    PLATFORM_RISCV_XLEN = 32
+  else
+    PLATFORM_RISCV_XLEN = 64
+  endif
+endif
+
 # Setup list of objects.mk files
 ifdef PLATFORM
 platform-object-mks=$(shell if [ -d $(platform_dir) ]; then find $(platform_dir) -iname "objects.mk" | sort -r; fi)
@@ -112,14 +121,6 @@ deps-y+=$(platform-common-objs-path-y:.o=.dep)
 deps-y+=$(lib-objs-path-y:.o=.dep)
 deps-y+=$(firmware-objs-path-y:.o=.dep)
 
-# Setup platform XLEN, ABI, ISA and Code Model
-ifndef PLATFORM_RISCV_XLEN
-  ifeq ($(OPENSBI_CC_XLEN), 32)
-    PLATFORM_RISCV_XLEN = 32
-  else
-    PLATFORM_RISCV_XLEN = 64
-  endif
-endif
 ifndef PLATFORM_RISCV_ABI
   ifeq ($(PLATFORM_RISCV_XLEN), 32)
     PLATFORM_RISCV_ABI = ilp$(PLATFORM_RISCV_XLEN)


### PR DESCRIPTION
Ensure the platform variable PLATFORM_RISCV_XLEN is set before we parse
the platform files.

This fixes the 32-bit openSBI FW_JUMP_ADDR.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>