### PR TITLE
firmware: Move _boot_hart_done to the data section & Add a barrier instruction for wait for boot hart

### DIFF
--- a/firmware/fw_base.S
+++ b/firmware/fw_base.S
@@ -114,6 +114,7 @@ _fdt_reloc_done:
 
 	/* Wait for boot hart */
 _wait_for_boot_hart:
+	fence	rw, rw
 	la	a4, _boot_hart_done
 	REG_L	a5, (a4)
 	beqz	a5, _wait_for_boot_hart

--- a/firmware/fw_base.S
+++ b/firmware/fw_base.S
@@ -111,12 +111,6 @@ _fdt_reloc_done:
 	la	a4, _boot_hart_done
 	li	a5, 1
 	REG_S	a5, (a4)
-	j	_wait_for_boot_hart
-
-	.align	3
-_boot_hart_done:
-	RISCV_PTR	0
-	.align	3
 
 	/* Wait for boot hart */
 _wait_for_boot_hart:
@@ -196,6 +190,11 @@ _start_warm:
 
 	/* We don't expect to reach here hence just hang */
 	j	_start_hang
+
+	.align 3
+	.section .data, "aw"
+_boot_hart_done:
+	RISCV_PTR	0
 
 	.align 3
 	.section .entry, "ax", %progbits


### PR DESCRIPTION
Writable code section can cause some security problems, so move _boot_hart_done
to the data section

Signed-off-by: Xiang Wang <wxjstz@126.com>