### PR TITLE
platform: Make the `platform` read-only

### DIFF
--- a/include/sbi/sbi_platform.h
+++ b/include/sbi/sbi_platform.h
@@ -110,10 +110,10 @@ struct sbi_platform {
 
 /** Get pointer to sbi_platform for sbi_scratch pointer */
 #define sbi_platform_ptr(__s)	\
-	((struct sbi_platform *)((__s)->platform_addr))
+	((const struct sbi_platform *)((__s)->platform_addr))
 /** Get pointer to sbi_platform for current HART */
 #define sbi_platform_thishart_ptr()	\
-	((struct sbi_platform *)(sbi_scratch_thishart_ptr()->platform_addr))
+	((const struct sbi_platform *)(sbi_scratch_thishart_ptr()->platform_addr))
 /** Check whether the platform supports timer value */
 #define sbi_platform_has_timer_value(__p)	\
 	((__p)->features & SBI_PLATFORM_HAS_TIMER_VALUE)
@@ -140,7 +140,7 @@ struct sbi_platform {
  *
  * @return pointer to platform name on success and NULL on failure
  */
-static inline const char *sbi_platform_name(struct sbi_platform *plat)
+static inline const char *sbi_platform_name(const struct sbi_platform *plat)
 {
 	if (plat)
 		return plat->name;
@@ -155,7 +155,7 @@ static inline const char *sbi_platform_name(struct sbi_platform *plat)
  *
  * @return TRUE if HART is disabled and FALSE otherwise
  */
-static inline bool sbi_platform_hart_disabled(struct sbi_platform *plat,
+static inline bool sbi_platform_hart_disabled(const struct sbi_platform *plat,
 					      u32 hartid)
 {
 	if (plat && (plat->disabled_hart_mask & (1 << hartid)))
@@ -170,7 +170,7 @@ static inline bool sbi_platform_hart_disabled(struct sbi_platform *plat,
  *
  * @return total number of HARTs
  */
-static inline u32 sbi_platform_hart_count(struct sbi_platform *plat)
+static inline u32 sbi_platform_hart_count(const struct sbi_platform *plat)
 {
 	if (plat)
 		return plat->hart_count;
@@ -184,7 +184,7 @@ static inline u32 sbi_platform_hart_count(struct sbi_platform *plat)
  *
  * @return stack size in bytes
  */
-static inline u32 sbi_platform_hart_stack_size(struct sbi_platform *plat)
+static inline u32 sbi_platform_hart_stack_size(const struct sbi_platform *plat)
 {
 	if (plat)
 		return plat->hart_stack_size;
@@ -199,7 +199,7 @@ static inline u32 sbi_platform_hart_stack_size(struct sbi_platform *plat)
  *
  * @return 0 on success and negative error code on failure
  */
-static inline int sbi_platform_early_init(struct sbi_platform *plat,
+static inline int sbi_platform_early_init(const struct sbi_platform *plat,
 					  bool cold_boot)
 {
 	if (plat && plat->early_init)
@@ -215,7 +215,7 @@ static inline int sbi_platform_early_init(struct sbi_platform *plat,
  *
  * @return 0 on success and negative error code on failure
  */
-static inline int sbi_platform_final_init(struct sbi_platform *plat,
+static inline int sbi_platform_final_init(const struct sbi_platform *plat,
 					  bool cold_boot)
 {
 	if (plat && plat->final_init)
@@ -231,7 +231,7 @@ static inline int sbi_platform_final_init(struct sbi_platform *plat,
  *
  * @return number of PMP regions
  */
-static inline u32 sbi_platform_pmp_region_count(struct sbi_platform *plat,
+static inline u32 sbi_platform_pmp_region_count(const struct sbi_platform *plat,
 						u32 hartid)
 {
 	if (plat && plat->pmp_region_count)
@@ -252,7 +252,7 @@ static inline u32 sbi_platform_pmp_region_count(struct sbi_platform *plat,
  *
  * @return 0 on success and negative error code on failure
  */
-static inline int sbi_platform_pmp_region_info(struct sbi_platform *plat,
+static inline int sbi_platform_pmp_region_info(const struct sbi_platform *plat,
 					       u32 hartid, u32 index,
 					       ulong *prot, ulong *addr,
 					       ulong *log2size)
@@ -269,7 +269,7 @@ static inline int sbi_platform_pmp_region_info(struct sbi_platform *plat,
  * @param plat pointer to struct sbi_platform
  * @param ch character to write
  */
-static inline void sbi_platform_console_putc(struct sbi_platform *plat,
+static inline void sbi_platform_console_putc(const struct sbi_platform *plat,
 					     char ch)
 {
 	if (plat && plat->console_putc)
@@ -283,7 +283,7 @@ static inline void sbi_platform_console_putc(struct sbi_platform *plat,
  *
  * @return character read from console input
  */
-static inline int sbi_platform_console_getc(struct sbi_platform *plat)
+static inline int sbi_platform_console_getc(const struct sbi_platform *plat)
 {
 	if (plat && plat->console_getc)
 		return plat->console_getc();
@@ -297,7 +297,7 @@ static inline int sbi_platform_console_getc(struct sbi_platform *plat)
  *
  * @return 0 on success and negative error code on failure
  */
-static inline int sbi_platform_console_init(struct sbi_platform *plat)
+static inline int sbi_platform_console_init(const struct sbi_platform *plat)
 {
 	if (plat && plat->console_init)
 		return plat->console_init();
@@ -312,7 +312,7 @@ static inline int sbi_platform_console_init(struct sbi_platform *plat)
  *
  * @return 0 on success and negative error code on failure
  */
-static inline int sbi_platform_irqchip_init(struct sbi_platform *plat,
+static inline int sbi_platform_irqchip_init(const struct sbi_platform *plat,
 					    bool cold_boot)
 {
 	if (plat && plat->irqchip_init)
@@ -326,7 +326,7 @@ static inline int sbi_platform_irqchip_init(struct sbi_platform *plat,
  * @param plat pointer to struct sbi_platform
  * @param target_hart HART ID of IPI target
  */
-static inline void sbi_platform_ipi_send(struct sbi_platform *plat,
+static inline void sbi_platform_ipi_send(const struct sbi_platform *plat,
 					 u32 target_hart)
 {
 	if (plat && plat->ipi_send)
@@ -339,7 +339,7 @@ static inline void sbi_platform_ipi_send(struct sbi_platform *plat,
  * @param plat pointer to struct sbi_platform
  * @param target_hart HART ID of IPI target
  */
-static inline void sbi_platform_ipi_sync(struct sbi_platform *plat,
+static inline void sbi_platform_ipi_sync(const struct sbi_platform *plat,
 					 u32 target_hart)
 {
 	if (plat && plat->ipi_sync)
@@ -352,7 +352,7 @@ static inline void sbi_platform_ipi_sync(struct sbi_platform *plat,
  * @param plat pointer to struct sbi_platform
  * @param target_hart HART ID of IPI target
  */
-static inline void sbi_platform_ipi_clear(struct sbi_platform *plat,
+static inline void sbi_platform_ipi_clear(const struct sbi_platform *plat,
 					  u32 target_hart)
 {
 	if (plat && plat->ipi_clear)
@@ -367,7 +367,7 @@ static inline void sbi_platform_ipi_clear(struct sbi_platform *plat,
  *
  * @return 0 on success and negative error code on failure
  */
-static inline int sbi_platform_ipi_init(struct sbi_platform *plat,
+static inline int sbi_platform_ipi_init(const struct sbi_platform *plat,
 					bool cold_boot)
 {
 	if (plat && plat->ipi_init)
@@ -382,7 +382,7 @@ static inline int sbi_platform_ipi_init(struct sbi_platform *plat,
  *
  * @return 64bit timer value
  */
-static inline u64 sbi_platform_timer_value(struct sbi_platform *plat)
+static inline u64 sbi_platform_timer_value(const struct sbi_platform *plat)
 {
 	if (plat && plat->timer_value)
 		return plat->timer_value();
@@ -395,8 +395,9 @@ static inline u64 sbi_platform_timer_value(struct sbi_platform *plat)
  * @param plat pointer to struct struct sbi_platform
  * @param next_event timer value when timer event will happen
  */
-static inline void sbi_platform_timer_event_start(struct sbi_platform *plat,
-						  u64 next_event)
+static inline void sbi_platform_timer_event_start(
+					const struct sbi_platform *plat,
+					u64 next_event)
 {
 	if (plat && plat->timer_event_start)
 		plat->timer_event_start(next_event);
@@ -407,7 +408,8 @@ static inline void sbi_platform_timer_event_start(struct sbi_platform *plat,
  *
  * @param plat pointer to struct sbi_platform
  */
-static inline void sbi_platform_timer_event_stop(struct sbi_platform *plat)
+static inline void sbi_platform_timer_event_stop(
+					const struct sbi_platform *plat)
 {
 	if (plat && plat->timer_event_stop)
 		plat->timer_event_stop();
@@ -421,7 +423,7 @@ static inline void sbi_platform_timer_event_stop(struct sbi_platform *plat)
  *
  * @return 0 on success and negative error code on failure
  */
-static inline int sbi_platform_timer_init(struct sbi_platform *plat,
+static inline int sbi_platform_timer_init(const struct sbi_platform *plat,
 					  bool cold_boot)
 {
 	if (plat && plat->timer_init)
@@ -437,7 +439,7 @@ static inline int sbi_platform_timer_init(struct sbi_platform *plat,
  *
  * @return 0 on success and negative error code on failure
  */
-static inline int sbi_platform_system_reboot(struct sbi_platform *plat,
+static inline int sbi_platform_system_reboot(const struct sbi_platform *plat,
 					     u32 type)
 {
 	if (plat && plat->system_reboot)
@@ -453,7 +455,7 @@ static inline int sbi_platform_system_reboot(struct sbi_platform *plat,
  *
  * @return 0 on success and negative error code on failure
  */
-static inline int sbi_platform_system_shutdown(struct sbi_platform *plat,
+static inline int sbi_platform_system_shutdown(const struct sbi_platform *plat,
 					       u32 type)
 {
 	if (plat && plat->system_shutdown)

--- a/lib/sbi_console.c
+++ b/lib/sbi_console.c
@@ -11,7 +11,7 @@
 #include <sbi/sbi_console.h>
 #include <sbi/riscv_locks.h>
 
-static struct sbi_platform *console_plat = NULL;
+static const struct sbi_platform *console_plat = NULL;
 static spinlock_t console_out_lock = SPIN_LOCK_INITIALIZER;
 
 bool sbi_isprintable(char c)

--- a/lib/sbi_hart.c
+++ b/lib/sbi_hart.c
@@ -28,7 +28,7 @@ unsigned int sbi_current_hartid()
 
 static void mstatus_init(struct sbi_scratch *scratch, u32 hartid)
 {
-	struct sbi_platform *plat = sbi_platform_ptr(scratch);
+	const struct sbi_platform *plat = sbi_platform_ptr(scratch);
 
 	/* Enable FPU */
 	if (misa_extension('D') || misa_extension('F'))
@@ -79,7 +79,7 @@ static int fp_init(u32 hartid)
 
 static int delegate_traps(struct sbi_scratch *scratch, u32 hartid)
 {
-	struct sbi_platform *plat = sbi_platform_ptr(scratch);
+	const struct sbi_platform *plat = sbi_platform_ptr(scratch);
 	unsigned long interrupts, exceptions;
 
 	if (!misa_extension('S'))
@@ -122,7 +122,7 @@ unsigned long log2roundup(unsigned long x)
 
 void sbi_hart_pmp_dump(struct sbi_scratch *scratch)
 {
-	struct sbi_platform *plat = sbi_platform_ptr(scratch);
+	const struct sbi_platform *plat = sbi_platform_ptr(scratch);
 	unsigned long prot, addr, size, l2l;
 	unsigned int i;
 
@@ -160,7 +160,7 @@ static int pmp_init(struct sbi_scratch *scratch, u32 hartid)
 	u32 i, count;
 	unsigned long fw_start, fw_size_log2;
 	ulong prot, addr, log2size;
-	struct sbi_platform *plat = sbi_platform_ptr(scratch);
+	const struct sbi_platform *plat = sbi_platform_ptr(scratch);
 
 	if (!sbi_platform_has_pmp(plat))
 		return 0;
@@ -297,7 +297,7 @@ static unsigned long coldboot_wait_bitmap = 0;
 void sbi_hart_wait_for_coldboot(struct sbi_scratch *scratch, u32 hartid)
 {
 	unsigned long mipval;
-	struct sbi_platform *plat = sbi_platform_ptr(scratch);
+	const struct sbi_platform *plat = sbi_platform_ptr(scratch);
 
 	if ((sbi_platform_hart_count(plat) <= hartid) ||
 	    (COLDBOOT_WAIT_BITMAP_SIZE <= hartid))
@@ -324,7 +324,7 @@ void sbi_hart_wait_for_coldboot(struct sbi_scratch *scratch, u32 hartid)
 
 void sbi_hart_wake_coldboot_harts(struct sbi_scratch *scratch, u32 hartid)
 {
-	struct sbi_platform *plat = sbi_platform_ptr(scratch);
+	const struct sbi_platform *plat = sbi_platform_ptr(scratch);
 	int max_hart = sbi_platform_hart_count(plat);
 
 	for(int i = 0; i < max_hart ; i++) {

--- a/lib/sbi_init.c
+++ b/lib/sbi_init.c
@@ -32,7 +32,7 @@ static void __noreturn init_coldboot(struct sbi_scratch *scratch, u32 hartid)
 {
 	int rc;
 	char str[64];
-	struct sbi_platform *plat = sbi_platform_ptr(scratch);
+	const struct sbi_platform *plat = sbi_platform_ptr(scratch);
 
 	rc = sbi_system_early_init(scratch, TRUE);
 	if (rc)
@@ -96,7 +96,7 @@ static void __noreturn init_coldboot(struct sbi_scratch *scratch, u32 hartid)
 static void __noreturn init_warmboot(struct sbi_scratch *scratch, u32 hartid)
 {
 	int rc;
-	struct sbi_platform *plat = sbi_platform_ptr(scratch);
+	const struct sbi_platform *plat = sbi_platform_ptr(scratch);
 
 	if (!sbi_platform_has_hart_hotplug(plat))
 		sbi_hart_wait_for_coldboot(scratch, hartid);
@@ -156,7 +156,7 @@ void __noreturn sbi_init(struct sbi_scratch *scratch)
 {
 	bool coldboot = FALSE;
 	u32 hartid = sbi_current_hartid();
-	struct sbi_platform *plat = sbi_platform_ptr(scratch);
+	const struct sbi_platform *plat = sbi_platform_ptr(scratch);
 
 	if (sbi_platform_hart_disabled(plat, hartid))
 		sbi_hart_hang();

--- a/lib/sbi_ipi.c
+++ b/lib/sbi_ipi.c
@@ -22,7 +22,7 @@
 static int sbi_ipi_send(struct sbi_scratch *scratch, u32 hartid, u32 event)
 {
 	struct sbi_scratch *remote_scratch = NULL;
-	struct sbi_platform *plat = sbi_platform_ptr(scratch);
+	const struct sbi_platform *plat = sbi_platform_ptr(scratch);
 
 	if (sbi_platform_hart_disabled(plat, hartid))
 		return -1;
@@ -72,7 +72,7 @@ void sbi_ipi_clear_smode(struct sbi_scratch *scratch)
 
 void sbi_ipi_process(struct sbi_scratch *scratch)
 {
-	struct sbi_platform *plat = sbi_platform_ptr(scratch);
+	const struct sbi_platform *plat = sbi_platform_ptr(scratch);
 	volatile unsigned long ipi_type;
 	unsigned int ipi_event;
 	u32 hartid = sbi_current_hartid();

--- a/lib/sbi_timer.c
+++ b/lib/sbi_timer.c
@@ -39,7 +39,7 @@ u64 get_ticks(void)
 
 u64 sbi_timer_value(struct sbi_scratch *scratch)
 {
-	struct sbi_platform *plat = sbi_platform_ptr(scratch);
+	const struct sbi_platform *plat = sbi_platform_ptr(scratch);
 
 	if (sbi_platform_has_timer_value(plat))
 		return sbi_platform_timer_value(plat);

--- a/platform/kendryte/k210/platform.c
+++ b/platform/kendryte/k210/platform.c
@@ -98,7 +98,7 @@ static int k210_system_shutdown(u32 type)
 	return 0;
 }
 
-struct sbi_platform platform = {
+const struct sbi_platform platform = {
 
 	.name = "Kendryte K210",
 	.features = SBI_PLATFORM_HAS_TIMER_VALUE,

--- a/platform/qemu/sifive_u/platform.c
+++ b/platform/qemu/sifive_u/platform.c
@@ -125,7 +125,7 @@ static int sifive_u_system_down(u32 type)
 	return 0;
 }
 
-struct sbi_platform platform = {
+const struct sbi_platform platform = {
 	.name = "QEMU SiFive Unleashed",
 	.features = SBI_PLATFORM_DEFAULT_FEATURES,
 	.hart_count = SIFIVE_U_HART_COUNT,

--- a/platform/qemu/virt/platform.c
+++ b/platform/qemu/virt/platform.c
@@ -134,7 +134,7 @@ static int virt_system_down(u32 type)
 	return 0;
 }
 
-struct sbi_platform platform = {
+const struct sbi_platform platform = {
 	.name = "QEMU Virt Machine",
 	.features = SBI_PLATFORM_DEFAULT_FEATURES,
 	.hart_count = VIRT_HART_COUNT,

--- a/platform/sifive/fu540/platform.c
+++ b/platform/sifive/fu540/platform.c
@@ -187,7 +187,7 @@ static int fu540_system_down(u32 type)
 	return 0;
 }
 
-struct sbi_platform platform = {
+const struct sbi_platform platform = {
 	.name = "SiFive Freedom U540",
 	.features = SBI_PLATFORM_DEFAULT_FEATURES,
 	.hart_count = FU540_HART_COUNT,

--- a/platform/template/platform.c
+++ b/platform/template/platform.c
@@ -207,7 +207,7 @@ static int platform_system_shutdown(u32 type)
 /*
  * Platform descriptor.
  */
-struct sbi_platform platform = {
+const struct sbi_platform platform = {
 
 	.name = "platform-name",
 	.features = SBI_PLATFORM_DEFAULT_FEATURES,


### PR DESCRIPTION
platform should be a read-only variable, if it is placed in the data
segment, it may be exploited.

Signed-off-by: Xiang Wang \<wxjstz@126.com\>