### PR TITLE
lib: Allow console message to be quiesced

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ endif
 GENFLAGS	=	-I$(platform_dir)/include
 GENFLAGS	+=	-I$(platform_common_dir)/include
 GENFLAGS	+=	-I$(include_dir)
+GENFLAGS	+=	$(lib-genflags-y)
 GENFLAGS	+=	$(platform-common-genflags-y)
 GENFLAGS	+=	$(platform-genflags-y)
 GENFLAGS	+=	$(firmware-genflags-y)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ directory path, run:
 make O=<build_directory>
 ```
 
+By default OpenSBI outputs its banner and some generic details like platform
+and firmware on the serial console, and this can be quiesced by:
+```
+make QUIESCE=y
+```
+
 To generate files to be installed for using *libsbi.a* in other projects, run:
 ```
 make install
@@ -107,6 +113,11 @@ The platform specific library *libplatsbi.a* will be generated in the
 will be under the *build/platform/<platform_subdir>/firmware* directory.
 The compiled firmwares will be available in two different format: an ELF file
 and an expanded image file.
+
+The OpenSBI console output messages can also be quiesced by:
+```
+make PLATFORM=<platform_subdir> QUIESCE=y
+```
 
 To install *libsbi.a*, *libplatsbi.a*, and the compiled firmwares, run:
 ```

--- a/lib/objects.mk
+++ b/lib/objects.mk
@@ -23,3 +23,7 @@ lib-objs-y += sbi_misaligned_ldst.o
 lib-objs-y += sbi_system.o
 lib-objs-y += sbi_timer.o
 lib-objs-y += sbi_trap.o
+
+ifdef QUIESCE
+lib-genflags-y += -DQUIESCE
+endif

--- a/lib/sbi_console.c
+++ b/lib/sbi_console.c
@@ -362,6 +362,7 @@ int sbi_snprintf(char *out, u32 out_sz, const char *format, ...)
 
 int sbi_printf(const char *format, ...)
 {
+#ifndef QUIESCE
 	va_list args;
 	int retval;
 
@@ -372,6 +373,9 @@ int sbi_printf(const char *format, ...)
 	spin_unlock(&console_out_lock);
 
 	return retval;
+#else
+	return 0;
+#endif
 }
 
 int sbi_console_init(struct sbi_scratch *scratch)


### PR DESCRIPTION
By default OpenSBI outputs its banner and some generic details like
platform and firmware on the serial console. Sometimes we don't want
to print such messages hence a new 'QUIESCE' compile time option is
introduced to turn it off.