### PR TITLE
platform: plic fixes

### DIFF
--- a/platform/common/irqchip/plic.c
+++ b/platform/common/irqchip/plic.c
@@ -27,7 +27,10 @@ static volatile void *plic_base;
 
 static void plic_set_priority(u32 source, u32 val)
 {
-	writel(val, plic_base);
+	volatile void *plic_priority = plic_base +
+				PLIC_PRIORITY_BASE +
+				4 * source;
+	writel(val, plic_priority);
 }
 
 static void plic_set_thresh(u32 cntxid, u32 val)

--- a/platform/common/irqchip/plic.c
+++ b/platform/common/irqchip/plic.c
@@ -118,7 +118,7 @@ int plic_cold_irqchip_init(unsigned long base,
 	plic_base = (void *)base;
 
 	/* Configure default priorities of all IRQs */
-	for (i = 0; i < plic_num_sources; i++)
+	for (i = 1; i <= plic_num_sources; i++)
 		plic_set_priority(i, 1);
 
 	return 0;


### PR DESCRIPTION
- platform: plic: Fix plic_set_priority()
- platform: plic: Bypass interrupt ID 0's priority programming