### PR TITLE
lib: Return ENOTSUPP incase of invalid SBI function ID

### DIFF
--- a/lib/sbi_ecall.c
+++ b/lib/sbi_ecall.c
@@ -86,6 +86,8 @@ int sbi_ecall_handler(u32 hartid, ulong mcause,
 		ret = 0;
 		break;
 	default:
+		regs->a0 = SBI_ENOTSUPP;
+		ret = 0;
 		break;
 	};
 


### PR DESCRIPTION
OpenSBI should show error trace only if any valid SBI function
does not perform as expected.

However, OpenSBI should show notify the caller with a negative
error if given SBI function ID is not valid.

Signed-off-by: Atish Patra <atish.patra@wdc.com>