### PR TITLE
platform: plic: Fix comments of programming the interrupt enable register

### DIFF
--- a/platform/common/irqchip/plic.c
+++ b/platform/common/irqchip/plic.c
@@ -86,12 +86,13 @@ int plic_warm_irqchip_init(u32 target_hart,
 	if (plic_hart_count <= target_hart)
 		return -1;
 	
+	/* By default, disable all IRQs for M-mode of target HART */
 	if (m_cntx_id > -1) {
 		for (i = 0; i < ie_words; i++)
 			plic_set_ie(m_cntx_id, i, 0);
 	}
 
-	/* By default, enable all IRQs for S-mode of target HART */
+	/* By default, disable all IRQs for S-mode of target HART */
 	if (s_cntx_id > -1) {
 		for (i = 0; i < ie_words; i++)
 			plic_set_ie(s_cntx_id, i, 0);


### PR DESCRIPTION
The codes that currently program the interrupt enable register for
S-mode disagrees with what the comments say. Fix the comments.

While we are here, add one line comment to describe what is done
for M-mode too.