### PR TITLE
platform: Fix PLIC priority base offset

### DIFF
--- a/platform/common/irqchip/plic.c
+++ b/platform/common/irqchip/plic.c
@@ -14,7 +14,7 @@
 #include <plat/tinyfdt.h>
 #include <plat/irqchip/plic.h>
 
-#define PLIC_PRIORITY_BASE		0x0
+#define PLIC_PRIORITY_BASE		0x04
 #define PLIC_PENDING_BASE		0x1000
 #define PLIC_ENABLE_BASE		0x2000
 #define PLIC_ENABLE_STRIDE		0x80
@@ -29,7 +29,7 @@ static void plic_set_priority(u32 source, u32 val)
 {
 	volatile void *plic_priority = plic_base +
 				PLIC_PRIORITY_BASE +
-				4 * source;
+				4 * (source - 1);
 	writel(val, plic_priority);
 }
 


### PR DESCRIPTION
According to the FU540 and E31 manuals the PLIC source priority
address starts at an offset of 0x04 and not 0x00. To aviod confusion
update the address and source offset to match the documentation. This
causes no difference in functionality.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>