### PR TITLE
firmware: Introduce "options" in "struct sbi_scratch"

### DIFF
--- a/docs/firmware/fw.md
+++ b/docs/firmware/fw.md
@@ -75,3 +75,18 @@ make PLATFORM=<platform_subdir> FW_PAYLOAD_PATH=<payload path>
 The instructions to build each payload is different and the details can
 be found in the
 *docs/firmware/payload_<payload_name>.md* files.
+
+Options for OpenSBI Firmware behaviors
+--------------------------------------
+An optional compile time flag FW_OPTIONS can be used to control the OpenSBI
+firmware run-time behaviors.
+
+```
+make PLATFORM=<platform_subdir> FW_OPTIONS=<options>
+```
+
+FW_OPTIONS is a bitwise or'ed value of various options, eg: *FW_OPTIONS=0x1*
+stands for disabling boot prints from the OpenSBI library.
+
+For all supported options, please check "enum sbi_scratch_options" in the
+*include/sbi/sbi_scratch.h* header file.

--- a/firmware/fw_base.S
+++ b/firmware/fw_base.S
@@ -81,6 +81,12 @@ _scratch_init:
 	la	a4, _hartid_to_scratch
 	REG_S	a4, SBI_SCRATCH_HARTID_TO_SCRATCH_OFFSET(tp)
 	REG_S	zero, SBI_SCRATCH_TMP0_OFFSET(tp)
+#ifdef FW_OPTIONS
+	li	a4, FW_OPTIONS
+	REG_S	a4, SBI_SCRATCH_OPTIONS_OFFSET(tp)
+#else
+	REG_S	zero, SBI_SCRATCH_OPTIONS_OFFSET(tp)
+#endif
 	add	t1, t1, t2
 	blt	t1, s7, _scratch_init
 

--- a/firmware/objects.mk
+++ b/firmware/objects.mk
@@ -50,3 +50,7 @@ endif
 ifdef FW_PAYLOAD_FDT_ADDR
 firmware-genflags-$(FW_PAYLOAD) += -DFW_PAYLOAD_FDT_ADDR=$(FW_PAYLOAD_FDT_ADDR)
 endif
+
+ifdef FW_OPTIONS
+firmware-genflags-y += -DFW_OPTIONS=$(FW_OPTIONS)
+endif

--- a/include/sbi/sbi_scratch.h
+++ b/include/sbi/sbi_scratch.h
@@ -70,6 +70,12 @@ struct sbi_scratch {
 	unsigned long options;
 } __packed;
 
+/** Possible options for OpenSBI library */
+enum sbi_scratch_options {
+	/** Disable prints during boot */
+	SBI_SCRATCH_NO_BOOT_PRINTS		= (1 << 0),
+};
+
 /** Get pointer to sbi_scratch for current HART */
 #define sbi_scratch_thishart_ptr()	\
 ((struct sbi_scratch *)csr_read(CSR_MSCRATCH))

--- a/include/sbi/sbi_scratch.h
+++ b/include/sbi/sbi_scratch.h
@@ -30,6 +30,8 @@
 #define SBI_SCRATCH_HARTID_TO_SCRATCH_OFFSET	(7 * __SIZEOF_POINTER__)
 /** Offset of tmp0 member in sbi_scratch */
 #define SBI_SCRATCH_TMP0_OFFSET			(8 * __SIZEOF_POINTER__)
+/** Offset of options member in sbi_scratch */
+#define SBI_SCRATCH_OPTIONS_OFFSET		(9 * __SIZEOF_POINTER__)
 
 /** sbi_ipi_data is located behind sbi_scratch. This struct is not packed. */
 /** Offset of ipi_type in sbi_ipi_data */
@@ -64,6 +66,8 @@ struct sbi_scratch {
 	unsigned long hartid_to_scratch;
 	/** Temporary storage */
 	unsigned long tmp0;
+	/** Options for OpenSBI library */
+	unsigned long options;
 } __packed;
 
 /** Get pointer to sbi_scratch for current HART */

--- a/lib/sbi_init.c
+++ b/lib/sbi_init.c
@@ -91,7 +91,8 @@ static void __noreturn init_coldboot(struct sbi_scratch *scratch, u32 hartid)
 	if (rc)
 		sbi_hart_hang();
 
-	sbi_boot_prints(scratch, hartid);
+	if (!(scratch->options & SBI_SCRATCH_NO_BOOT_PRINTS))
+		sbi_boot_prints(scratch, hartid);
 
 	if (!sbi_platform_has_hart_hotplug(plat))
 		sbi_hart_wake_coldboot_harts(scratch, hartid);


### PR DESCRIPTION
Introduce "options" in "struct sbi_scratch" and firmware can update it based on optional compile time flags before calling sbi_init().

For example, we can use it to conditionally disable the boot prints.