### PR TITLE
firmware: Fix source fdt alignment

### DIFF
--- a/firmware/fw_base.S
+++ b/firmware/fw_base.S
@@ -119,7 +119,7 @@ _prev_arg1_override_done:
 	 */
 	beqz	a1, _fdt_reloc_done
 	/* Mask values in a3 and a4 */
-	li	a3, ~0xf
+	li	a3, ~(__SIZEOF_POINTER__ - 1)
 	li	a4, 0xff
 	/* t1 = destination FDT start address */
 	add	s0, a0, zero


### PR DESCRIPTION
When I tried to start opensbi with coreboot, I found that aligning to a 16-byte
boundary would make a copy error.

The current riscv platform does not have a 128-bit machine, and there is no need
to align the 16-byte boundary. Corrected to align to an 8-byte boundary.

Signed-off-by: Xiang Wang \<wxjstz@126.com\>