### PR TITLE
platform/sifive/fu540: add feature to change next_addr by fdt

### DIFF
--- a/platform/common/next_addr.c
+++ b/platform/common/next_addr.c
@@ -1,0 +1,33 @@
+#include <libfdt.h>
+#include <sbi/riscv_atomic.h>
+#include <sbi/sbi_types.h>
+#include <sbi/sbi_scratch.h>
+
+static uint64_t next_addr;
+static atomic_t done = ATOMIC_INITIALIZER(0);
+
+void update_next_addr(bool coolboot)
+{
+	if (coolboot) {
+		do {
+			void *fdt = sbi_scratch_thishart_arg1_ptr();
+			int chosen_offset = fdt_path_offset(fdt, "/chosen");
+			if (chosen_offset < 0)
+				break;
+			int len;
+			const void *prop =
+			    fdt_getprop(fdt, chosen_offset, "opensbi,next_addr",
+					&len);
+			if (prop == NULL)
+				break;
+			if (len == 4)
+				next_addr = fdt32_ld(prop);
+			if (len == 8)
+				next_addr = fdt64_ld(prop);
+		} while (0);
+		atomic_write(&done, 1);
+	}
+	while (atomic_read(&done) == 0) ;
+	if (next_addr)
+		sbi_scratch_thishart_ptr()->next_addr = next_addr;
+}

--- a/platform/common/objects.mk
+++ b/platform/common/objects.mk
@@ -8,3 +8,4 @@
 #
 
 platform-common-objs-y += tinyfdt.o
+platform-common-objs-y += next_addr.o

--- a/platform/sifive/fu540/platform.c
+++ b/platform/sifive/fu540/platform.c
@@ -86,9 +86,14 @@ static void fu540_modify_dt(void *fdt)
 	plic_fdt_fixup(fdt, "riscv,plic0");
 }
 
+
+extern void update_next_addr(bool coolboot);
+
 static int fu540_final_init(bool cold_boot)
 {
 	void *fdt;
+
+	update_next_addr(cold_boot);
 
 	if (!cold_boot)
 		return 0;


### PR DESCRIPTION
The opensbi, kernel and initramfs may be dynamically loaded by the bootloader,
at which point the bootloader needs to pass the kernel's starting address to
opensbi. Can be passed through the "opensbi,next-addr" of the fdt's "chosen"
node.

Signed-off-by: Xiang Wang <wxjstz@126.com>