### PR TITLE
Add support for Ariane FPGA SoC

### DIFF
--- a/docs/platform/ariane-fpga.md
+++ b/docs/platform/ariane-fpga.md
@@ -1,0 +1,37 @@
+Ariane FPGA SoC Platform
+==========================
+Ariane is a 6-stage, single issue, in-order CPU which implements the 64-bit RISC-V instruction set.
+The Ariane FPGA development platform is based on FPGA FPGA SoC(which currently supports only  Genesys 2 board) and is capable
+of running Linux.
+ The FPGA SoC currently contains the following peripherals:
+- DDR3 memory controller
+- SPI controller to conncet to an SDCard
+- Ethernet controller
+- JTAG port (see debugging section below)
+- Bootrom containing zero stage bootloader and device tree.
+
+To build platform specific library and firmwares, provide the
+*PLATFORM=ariane-fpga* parameter to the top level `make` command.
+
+Platform Options
+----------------
+
+The *Ariane FPGA* platform does not have any platform-specific
+options.
+
+Building Ariane FPGA Platform
+-----------------------------
+**Linux Kernel Payload**
+
+
+```
+make PLATFORM=ariane-fpga FW_PAYLOAD_PATH=<linux_build_directory>/arch/riscv/boot/Image
+```
+
+Booting Ariane FPGA Platform
+-----------------------------
+
+**Linux Kernel Payload**
+
+As Linux kernel image is embedded in the OpenSBI firmware binary, Ariane will directly
+boot into Linux directly after powered on.

--- a/docs/platform/platform.md
+++ b/docs/platform/platform.md
@@ -21,6 +21,9 @@ OpenSBI currently supports the following virtual and hardware platforms:
 * **Kendryte K210 SoC**: Platform support for the Kendryte K210 SoC used on
   boards such as the Kendryte KD233 or the Sipeed MAIX Dock.
 
+* **Ariane FPGA SoC**: Platform support for the Ariane FPGA SoC used on
+  Genesys 2 board.
+
 The code for these supported platforms can be used as example to implement
 support for other platforms. The *platform/template* directory also provides
 template files for implementing support for a new platform. The *object.mk*,
@@ -30,3 +33,4 @@ facilitate the implementation.
 [qemu_virt.md]: qemu_virt.md
 [qemu_sifive_u.md]: qemu_sifive_u.md
 [sifive_fu540.md]: sifive_fu540.md
+[ariane-fpga.md]: ariane-fpga.md

--- a/include/sbi_utils/irqchip/plic.h
+++ b/include/sbi_utils/irqchip/plic.h
@@ -18,4 +18,8 @@ int plic_warm_irqchip_init(u32 target_hart, int m_cntx_id, int s_cntx_id);
 
 int plic_cold_irqchip_init(unsigned long base, u32 num_sources, u32 hart_count);
 
+void plic_set_thresh(u32 cntxid, u32 val);
+
+void plic_set_ie(u32 cntxid, u32 word_index, u32 val);
+
 #endif

--- a/lib/utils/irqchip/plic.c
+++ b/lib/utils/irqchip/plic.c
@@ -33,14 +33,14 @@ static void plic_set_priority(u32 source, u32 val)
 	writel(val, plic_priority);
 }
 
-static void plic_set_thresh(u32 cntxid, u32 val)
+void plic_set_thresh(u32 cntxid, u32 val)
 {
 	volatile void *plic_thresh =
 		plic_base + PLIC_CONTEXT_BASE + PLIC_CONTEXT_STRIDE * cntxid;
 	writel(val, plic_thresh);
 }
 
-static void plic_set_ie(u32 cntxid, u32 word_index, u32 val)
+void plic_set_ie(u32 cntxid, u32 word_index, u32 val)
 {
 	volatile void *plic_ie =
 		plic_base + PLIC_ENABLE_BASE + PLIC_ENABLE_STRIDE * cntxid;

--- a/platform/ariane-fpga/config.mk
+++ b/platform/ariane-fpga/config.mk
@@ -1,0 +1,41 @@
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2019 FORTH-ICS/CARV
+#		Panagiotis Peristerakis <perister@ics.forth.gr>
+#
+
+#for more infos, check out /platform/template/config.mk
+
+PLATFORM_RISCV_XLEN = 64
+
+# Common drivers to enable
+PLATFORM_SERIAL_UART8250=y
+PLATFORM_IRQCHIP_PLIC=y
+PLATFORM_SYS_CLINT=y
+
+# Blobs to build
+FW_TEXT_START=0x80000000
+FW_JUMP=n
+
+ifeq ($(PLATFORM_RISCV_XLEN), 32)
+ # This needs to be 4MB aligned for 32-bit support
+ FW_JUMP_ADDR=0x80400000
+ else
+ # This needs to be 2MB aligned for 64-bit support
+ FW_JUMP_ADDR=0x80200000
+ endif
+FW_JUMP_FDT_ADDR=0x82200000
+
+# Firmware with payload configuration.
+FW_PAYLOAD=y
+
+ifeq ($(PLATFORM_RISCV_XLEN), 32)
+# This needs to be 4MB aligned for 32-bit support
+  FW_PAYLOAD_OFFSET=0x400000
+else
+# This needs to be 2MB aligned for 64-bit support
+  FW_PAYLOAD_OFFSET=0x200000
+endif
+FW_PAYLOAD_FDT_ADDR=0x82200000
+FW_PAYLOAD_ALIGN=0x1000

--- a/platform/ariane-fpga/objects.mk
+++ b/platform/ariane-fpga/objects.mk
@@ -1,0 +1,8 @@
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2019 FORTH-ICS/CARV
+#		Panagiotis Peristerakis <perister@ics.forth.gr>
+#
+
+platform-objs-y += platform.o

--- a/platform/ariane-fpga/platform.c
+++ b/platform/ariane-fpga/platform.c
@@ -1,0 +1,201 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 2019 FORTH-ICS/CARV
+ *				Panagiotis Peristerakis <perister@ics.forth.gr>
+ */
+
+#include <sbi/riscv_encoding.h>
+#include <sbi/sbi_const.h>
+#include <sbi/sbi_platform.h>
+#include <sbi_utils/irqchip/plic.h>
+#include <sbi_utils/serial/uart8250.h>
+#include <sbi_utils/sys/clint.h>
+#include <sbi/sbi_console.h>
+#include <sbi/sbi_hart.h>
+#include <libfdt.h>
+#include <fdt.h>
+#include <sbi_utils/irqchip/plic.h>
+#include <sbi/riscv_io.h>
+
+#define ARIANE_UART_ADDR			0x10000000
+#define ARIANE_UART_FREQ			50000000
+#define ARIANE_UART_BAUDRATE			115200
+#define ARIANE_UART_REG_SHIFT			2
+#define ARIANE_UART_REG_WIDTH			4
+#define ARIANE_PLIC_ADDR			0xc000000
+#define ARIANE_PLIC_NUM_SOURCES			3
+#define ARIANE_HART_COUNT			1
+#define ARIANE_CLINT_ADDR 0x2000000
+#define PLIC_ENABLE_BASE		0x2000
+#define PLIC_ENABLE_STRIDE		0x80
+#define PLIC_CONTEXT_BASE		0x200000
+#define PLIC_CONTEXT_STRIDE		0x1000
+
+#define SBI_ARIANE_FEATURES	\
+	(SBI_PLATFORM_HAS_TIMER_VALUE | \
+	 SBI_PLATFORM_HAS_SCOUNTEREN | \
+	 SBI_PLATFORM_HAS_MCOUNTEREN | \
+	 SBI_PLATFORM_HAS_MFAULTS_DELEGATION)
+
+
+/*
+ * Ariane platform early initialization.
+ */
+static int ariane_early_init(bool cold_boot)
+{
+	/* For now nothing to do. */
+	return 0;
+}
+
+/*
+ * Ariane platform final initialization.
+ */
+static int ariane_final_init(bool cold_boot)
+{
+	void *fdt;
+
+	if (!cold_boot)
+		return 0;
+	fdt = sbi_scratch_thishart_arg1_ptr();
+	plic_fdt_fixup(fdt, "riscv,plic0");
+	return 0;
+}
+
+/*
+ * Initialize the ariane console.
+ */
+static int ariane_console_init(void)
+{
+	return uart8250_init(ARIANE_UART_ADDR,
+						 ARIANE_UART_FREQ,
+						 ARIANE_UART_BAUDRATE,
+						ARIANE_UART_REG_SHIFT,
+						ARIANE_UART_REG_WIDTH);
+}
+
+static int plic_ariane_warm_irqchip_init(u32 target_hart,
+			   int m_cntx_id, int s_cntx_id)
+{
+	size_t i, ie_words = ARIANE_PLIC_NUM_SOURCES / 32 + 1;
+
+	if (ARIANE_HART_COUNT <= target_hart)
+		return -1;
+	/* By default, enable all IRQs for M-mode of target HART */
+	if (m_cntx_id > -1) {
+		for (i = 0; i < ie_words; i++)
+			plic_set_ie(m_cntx_id, i, 1);
+	}
+	/* Enable all IRQs for S-mode of target HART */
+	if (s_cntx_id > -1) {
+		for (i = 0; i < ie_words; i++)
+			plic_set_ie(s_cntx_id, i, 1);
+	}
+	/* By default, enable M-mode threshold */
+	if (m_cntx_id > -1)
+		plic_set_thresh(m_cntx_id, 1);
+	/* By default, disable S-mode threshold */
+	if (s_cntx_id > -1)
+		plic_set_thresh(s_cntx_id, 0);
+
+	return 0;
+}
+
+/*
+ * Initialize the ariane interrupt controller for current HART.
+ */
+static int ariane_irqchip_init(bool cold_boot)
+{
+	u32 hartid = sbi_current_hartid();
+	int ret;
+
+	if (cold_boot) {
+		ret = plic_cold_irqchip_init(ARIANE_PLIC_ADDR,
+					     ARIANE_PLIC_NUM_SOURCES,
+					     ARIANE_HART_COUNT);
+		if (ret)
+			return ret;
+	}
+	return plic_ariane_warm_irqchip_init(hartid,
+					2 * hartid, 2 * hartid + 1);
+}
+
+/*
+ * Initialize IPI for current HART.
+ */
+static int ariane_ipi_init(bool cold_boot)
+{
+	int ret;
+
+	if (cold_boot) {
+		ret = clint_cold_ipi_init(ARIANE_CLINT_ADDR,
+					  ARIANE_HART_COUNT);
+		if (ret)
+			return ret;
+	}
+
+	return clint_warm_ipi_init();
+}
+
+/*
+ * Initialize ariane timer for current HART.
+ */
+static int ariane_timer_init(bool cold_boot)
+{
+	int ret;
+
+	if (cold_boot) {
+		ret = clint_cold_timer_init(ARIANE_CLINT_ADDR,
+							ARIANE_HART_COUNT);
+		if (ret)
+			return ret;
+	}
+
+	return clint_warm_timer_init();
+}
+
+/*
+ * Reboot the ariane.
+ */
+static int ariane_system_reboot(u32 type)
+{
+	/* For now nothing to do. */
+	sbi_printf("System reboot\n");
+	return 0;
+}
+
+/*
+ * Shutdown or poweroff the ariane.
+ */
+static int ariane_system_shutdown(u32 type)
+{
+	/* For now nothing to do. */
+	sbi_printf("System shutdown\n");
+	return 0;
+}
+
+/*
+ * Platform descriptor.
+ */
+const struct sbi_platform platform = {
+	.name = "ARIANE RISC-V",
+	.features = SBI_ARIANE_FEATURES,
+	.hart_count = ARIANE_HART_COUNT,
+	.hart_stack_size = 4096,
+	.disabled_hart_mask = 0,
+	.early_init = ariane_early_init,
+	.final_init = ariane_final_init,
+	.console_init = ariane_console_init,
+	.console_putc = uart8250_putc,
+	.console_getc = uart8250_getc,
+	.irqchip_init = ariane_irqchip_init,
+	.ipi_init = ariane_ipi_init,
+	.ipi_send = clint_ipi_send,
+	.ipi_sync = clint_ipi_sync,
+	.ipi_clear = clint_ipi_clear,
+	.timer_init = ariane_timer_init,
+	.timer_value = clint_timer_value,
+	.timer_event_start = clint_timer_event_start,
+	.timer_event_stop = clint_timer_event_stop,
+	.system_reboot = ariane_system_reboot,
+	.system_shutdown = ariane_system_shutdown
+};


### PR DESCRIPTION
This patch adds support for Ariane platform.
We needed to enable PLIC interrupts early(like on BBL) due to some issue of the design.
Otherwise, Linux would not get any external interrupts.

Signed-off-by: Panagiotis Peristerakis <perister@ics.forth.gr>