### PR TITLE
firmware: Fix the loop condition of _wait_relocate_copy_done section

### DIFF
--- a/firmware/fw_base.S
+++ b/firmware/fw_base.S
@@ -121,7 +121,7 @@ _wait_relocate_copy_done:
 	nop
 	nop
 	nop
-	bne	t4, t5, 1b
+	bgt     t4, t5, 1b
 	jr	t3
 _relocate_done:
 


### PR DESCRIPTION
If core-0 have finished _fdt_reloc_done but any of other cores has not
yet left the loop in _wait_relocate_copy_done, they could never leave
the loop because _boot_status is not equal to 1.