### PR TITLE
Priority for interrupt source 53 is not configured

### DIFF
--- a/lib/utils/irqchip/plic.c
+++ b/lib/utils/irqchip/plic.c
@@ -15,7 +15,7 @@
 #include <libfdt.h>
 #include <fdt.h>
 
-#define PLIC_PRIORITY_BASE 0x0
+#define PLIC_PRIORITY_BASE 0x4
 #define PLIC_PENDING_BASE 0x1000
 #define PLIC_ENABLE_BASE 0x2000
 #define PLIC_ENABLE_STRIDE 0x80
@@ -111,7 +111,7 @@ int plic_cold_irqchip_init(unsigned long base, u32 num_sources, u32 hart_count)
 	plic_base	 = (void *)base;
 
 	/* Configure default priorities of all IRQs */
-	for (i = 1; i <= plic_num_sources; i++)
+	for (i = 0; i <= plic_num_sources; i++)
 		plic_set_priority(i, 1);
 
 	return 0;


### PR DESCRIPTION
The value of `PLIC_PRIORITY_BASE` seems wrong. According to the PLIC memory map from the FU540-C000 manual the priority registers start at address `0x4`, `0x0` is reserved. The issue here being, the last address the loop in `plic_cold_irqchip_init` writes to is `0xD4`. Therefore, the priority of interrupt source 53 (address `0xD8`) remains unconfigured.

https://github.com/riscv/opensbi/blob/6ddf71e6e90878ee107b0d9f98492ad27d31c73a/lib/utils/irqchip/plic.c#L113-L115