### PR TITLE
include: sbi_platform: fix compilation for GCC-9

### DIFF
--- a/include/sbi/sbi_platform.h
+++ b/include/sbi/sbi_platform.h
@@ -200,13 +200,13 @@ struct sbi_platform {
  *
  * @param plat pointer to struct sbi_platform
  *
- * @return pointer to platform name on success and NULL on failure
+ * @return pointer to platform name on success and "Unknown" on failure
  */
 static inline const char *sbi_platform_name(const struct sbi_platform *plat)
 {
 	if (plat)
 		return plat->name;
-	return NULL;
+	return "Unknown";
 }
 
 /**


### PR DESCRIPTION
GCC-9 will throw a warning when using the %s format specifier with a
possible NULL parameter and since -Werror is used, the compilation breaks
for GCC-9.

In function 'sbi_boot_prints',
    inlined from 'init_coldboot' at <redacted>/opensbi/lib/sbi/sbi_init.c:107:3,
    inlined from 'sbi_init' at <redacted>/opensbi/lib/sbi/sbi_init.c:189:3:
<redacted>/opensbi/lib/sbi/sbi_init.c:56:2: error: '%s' directive argument is null [-Werror=format-overflow=]
   56 |  sbi_printf("Platform Name          : %s\n", sbi_platform_name(plat));
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

This is one way to fix this, currently there is nothing in the tree
checking for `sbi_platfrom_name() == NULL` so we can just return "Unknown"
instead of NULL on failure.

Signed-off-by: Martin Pietryka <martin@pietryka.at>

NOTE: This can be considered a proposal, any way of fixing this issue is a trivial change, so if this is not the preferred way, just close this PR and consider it as a bug-report.