### PR TITLE
makefile: add support for building on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,18 @@
 # o  Do not print "Entering directory ...";
 MAKEFLAGS += -r --no-print-directory
 
+# readlink -f requires GNU readlink
+# FIXME: could these calls be changed to use $(realpath ...) instead?
+ifeq ($(shell uname -s),Darwin)
+READLINK ?= greadlink
+else
+READLINK ?= readlink
+endif
+
 # Find out source, build, and install directories
 src_dir=$(CURDIR)
 ifdef O
- build_dir=$(shell readlink -f $(O))
+ build_dir=$(shell $(READLINK) -f $(O))
 else
  build_dir=$(CURDIR)/build
 endif
@@ -23,7 +31,7 @@ ifeq ($(build_dir),$(CURDIR))
 $(error Build directory is same as source directory.)
 endif
 ifdef I
- install_dir=$(shell readlink -f $(I))
+ install_dir=$(shell $(READLINK) -f $(I))
 else
  install_dir=$(CURDIR)/install
 endif
@@ -34,7 +42,7 @@ ifeq ($(install_dir),$(build_dir))
 $(error Install directory is same as build directory.)
 endif
 ifdef PLATFORM_DIR
-  platform_dir_path=$(shell readlink -f $(PLATFORM_DIR))
+  platform_dir_path=$(shell $(READLINK) -f $(PLATFORM_DIR))
   ifdef PLATFORM
     platform_parent_dir=$(platform_dir_path)
   else


### PR DESCRIPTION
On macOS the readlink command does not include a -f flag. Instead default
to using GNU readlink (which is often installed as greadlink).

I am not sure why readlink -f is being used here instead of $(realpath ).
If that is also an acceptable solution I'll update the PR to use that instead.

Signed-off-by: Alex Richardson <Alexander.Richardson@cl.cam.ac.uk>