### PR TITLE
platform: sifive: fu540: allow sv32 as an mmu-type

### DIFF
--- a/platform/sifive/fu540/platform.c
+++ b/platform/sifive/fu540/platform.c
@@ -75,7 +75,8 @@ static void fu540_modify_dt(void *fdt)
 		sbi_sprintf(cpu_node, "/cpus/cpu@%d", i);
 		cpu_offset = fdt_path_offset(fdt, cpu_node);
 		mmu_type   = fdt_getprop(fdt, cpu_offset, "mmu-type", NULL);
-		if (mmu_type && (!strcmp(mmu_type, "riscv,sv39") ||
+		if (mmu_type && (!strcmp(mmu_type, "riscv,sv32") ||
+				 !strcmp(mmu_type, "riscv,sv39") ||
 				 !strcmp(mmu_type, "riscv,sv48")))
 			continue;
 		else


### PR DESCRIPTION
There has already been a commit to master which added 32-bit specific
fdt/payload addresses for the sifive/fu540 platform [\[0\]][0]. This commit
introduces another change for using sifive/fu540 as a 32-bit platform.
On 32-bit platforms, cores with the SV32 MMU type should not be
disabled. For this reason, this commit also allows using this MMU type
on the sifive/fu540 platform.

Alternatively it would also be possible to only allow SV39 and SV48 if
`__riscv_xlen == 64` and SV32 if `__riscv_xlen == 32`. Removing the
check entirely would also be an option.

[0]: https://github.com/riscv/opensbi/commit/66fb729a1e46a9a46e809f3b7867fef91477e494