### PR TITLE
lib: Allow the OS to map the regions that are protected by PMP

### DIFF
--- a/lib/utils/fdt/fdt_fixup.c
+++ b/lib/utils/fdt/fdt_fixup.c
@@ -70,7 +70,7 @@ void fdt_plic_fixup(void *fdt, const char *compat)
 
 static int fdt_resv_memory_update_node(void *fdt, unsigned long addr,
 				       unsigned long size, int index,
-				       int parent)
+				       int parent, bool no_map)
 {
 	int na = fdt_address_cells(fdt, 0);
 	int ns = fdt_size_cells(fdt, 0);
@@ -99,14 +99,16 @@ static int fdt_resv_memory_update_node(void *fdt, unsigned long addr,
 	if (subnode < 0)
 		return subnode;
 
-	/*
-	 * Tell operating system not to create a virtual
-	 * mapping of the region as part of its standard
-	 * mapping of system memory.
-	 */
-	err = fdt_setprop_empty(fdt, subnode, "no-map");
-	if (err < 0)
-		return err;
+	if (no_map) {
+		/*
+		 * Tell operating system not to create a virtual
+		 * mapping of the region as part of its standard
+		 * mapping of system memory.
+		 */
+		err = fdt_setprop_empty(fdt, subnode, "no-map");
+		if (err < 0)
+			return err;
+	}
 
 	/* encode the <reg> property value */
 	val = reg;
@@ -199,7 +201,8 @@ int fdt_reserved_memory_fixup(void *fdt)
 		 */
 		addr = scratch->fw_start & ~(scratch->fw_size - 1UL);
 		size = (1UL << log2roundup(scratch->fw_size));
-		return fdt_resv_memory_update_node(fdt, addr, size, 0, parent);
+		return fdt_resv_memory_update_node(fdt, addr, size,
+						   0, parent, true);
 	}
 
 	for (i = 0, j = 0; i < sbi_hart_pmp_count(scratch); i++) {
@@ -211,7 +214,7 @@ int fdt_reserved_memory_fixup(void *fdt)
 		if (prot & (PMP_R | PMP_W | PMP_X))
 			continue;
 
-		fdt_resv_memory_update_node(fdt, addr, size, j, parent);
+		fdt_resv_memory_update_node(fdt, addr, size, j, parent, false);
 		j++;
 	}
 


### PR DESCRIPTION
This is achieved by removing the 'no-map' property from the
'reserved-memory' node when PMP is present, otherwise we keep it as it
offers a small protection if the OS does not map this region at all.

If PMP is present, telling the OS not to map the reserved regions does not
add much protection since it only avoids access to regions that are already
protected by PMP. But by not allowing the OS to map those regions, it
creates holes in the OS system memory map and prevents the use of
hugepages which would generate, among other benefits, less TLB miss.

Signed-off-by: Alexandre Ghiti <alex@ghiti.fr>