### PR TITLE
lib: utils: Include sbi_strings.h directly

### DIFF
--- a/lib/utils/fdt/fdt_domain.c
+++ b/lib/utils/fdt/fdt_domain.c
@@ -13,6 +13,7 @@
 #include <sbi/sbi_error.h>
 #include <sbi/sbi_hartmask.h>
 #include <sbi/sbi_scratch.h>
+#include <sbi/sbi_string.h>
 #include <sbi_utils/fdt/fdt_domain.h>
 #include <sbi_utils/fdt/fdt_helper.h>
 


### PR DESCRIPTION
This file uses `sbi_strncpy`, `sbi_strncmp` and `sbi_memset`, which are defined in `sbi_strings.h`.
It should already be transitively included via `#include <sbi/sbi_scratch.h>` but my toolchain doesn't do that for some reason. Perhaps because the functions that refer to them are `static`?

Anyways, it would be good to directly reference the header here.